### PR TITLE
chore: JWT 보안 설정 보강 및 CORS 허용 범위 최소화

### DIFF
--- a/server/main/.gitignore
+++ b/server/main/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Local secrets - do not commit ###
+src/main/resources/application-local.properties

--- a/server/main/src/main/java/server/main/global/config/CorsConfig.java
+++ b/server/main/src/main/java/server/main/global/config/CorsConfig.java
@@ -15,7 +15,10 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedOriginPatterns(List.of(
+                "http://localhost:3000",
+                "http://localhost:5173"
+        ));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setExposedHeaders(List.of("Authorization"));

--- a/server/main/src/main/java/server/main/global/security/JwtTokenProvider.java
+++ b/server/main/src/main/java/server/main/global/security/JwtTokenProvider.java
@@ -1,15 +1,20 @@
 package server.main.global.security;
 
-import io.jsonwebtoken.*;
-import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.PostConstruct;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Base64;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import javax.crypto.SecretKey;
-import java.util.Base64;
-import java.util.Date;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
@@ -25,7 +30,23 @@ public class JwtTokenProvider {
 
     @PostConstruct
     public void init() {
-        byte[] keyBytes = Base64.getDecoder().decode(secret);
+        if (!org.springframework.util.StringUtils.hasText(secret)) {
+            throw new IllegalStateException(
+                "JWT secret이 설정되지 않았습니다. " +
+                "JWT_SECRET 환경변수 또는 application-local.properties를 확인하세요."
+            );
+        }
+        byte[] keyBytes;
+        try {
+            keyBytes = Base64.getDecoder().decode(secret);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("JWT secret이 유요한 Base64 형식이 아닙니다.", e);
+        }
+        if (keyBytes.length < 32) {
+            throw new IllegalStateException(
+                "JWT secret이 너무 짧습니다. 최소 32 bytes 이상이어야 합니다. (현재: " + keyBytes.length + " bytes)"
+            );
+        }
         this.secretKey = Keys.hmacShaKeyFor(keyBytes);
     }
 

--- a/server/main/src/main/resources/application.properties
+++ b/server/main/src/main/resources/application.properties
@@ -28,7 +28,8 @@ mybatis.configuration.map-underscore-to-camel-case=true
 
 
 # JWT
-jwt.secret=c3RvLXBvYy1qd3Qtc2VjcmV0LWtleS1mb3ItaHMyNTYtbXVzdC1iZS1hdC1sZWFzdC0zMmJ5dGVz
+# 실제 secret은 JWT_SECRET 환경변수 또는 application-local.properties에 설정
+jwt.secret=${JWT_SECRET:}
 jwt.access-token-expiration=3600000
 
 springdoc.swagger-ui.path=/swagger


### PR DESCRIPTION
  - jwt.secret을 환경변수(JWT_SECRET) 기반으로 변경
  - application-local.properties에 로컬 개발용 secret 분리 (git 제외)
  - JwtTokenProvider 초기화 시 null/blank, Base64 포맷, 키 길이 검증 추가
  - CORS 허용 origin을 localhost:3000, localhost:5173으로 제한