### PR TITLE
fix: 로그인 라우팅 및 sockjs 에러 수정

### DIFF
--- a/client/web/src/pages/AuthPage.jsx
+++ b/client/web/src/pages/AuthPage.jsx
@@ -20,9 +20,9 @@ export function AuthPage() {
   const [email, setEmail]           = useState('');
   const [password, setPassword]     = useState('');
 
-  function handleLogin() {
+  async function handleLogin() {
     if (!email.trim() || !password.trim()) return;
-    const isAdmin = login(email, password);
+    const isAdmin = await login(email, password);
     navigate(isAdmin ? '/admin' : '/');
   }
 
@@ -30,8 +30,8 @@ export function AuthPage() {
     setShowComplete(true);
   }
 
-  function handleSignupComplete() {
-    login('demo@sto.exchange', 'user');
+  async function handleSignupComplete() {
+    await login('demo@sto.exchange', 'user');
     navigate('/');
   }
 

--- a/client/web/vite.config.js
+++ b/client/web/vite.config.js
@@ -4,6 +4,16 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    global: 'globalThis',
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      define: {
+        global: 'globalThis',
+      },
+    },
+  },
   build: {
     outDir: 'dist',
   },


### PR DESCRIPTION
## 변경 내용

- 로그인 시 login() 결과를 wait하도록 수정
- 모든 계정이 관리자 페이지로 이동하던 문제 해결
- Vite 설정에 global -> globalThis 치환 추가
- sockjs-client의 global is not defined 오류 해결

## 확인 사항

- 일반 로그인 시 / 이동
- 관리자 로그인 시 /admin 이동
- WebSocket 연결 시 global is not defined 미발생