### PR TITLE
[FEAT] match 주문 요청/응답 DTO 및 내부 API 계약 정의

### DIFF
--- a/server/main/src/main/java/server/main/global/util/MatchClient.java
+++ b/server/main/src/main/java/server/main/global/util/MatchClient.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import server.main.order.dto.MatchOrderRequestDto;
+import server.main.order.dto.MatchResultDto;
 import server.main.order.dto.UpdateMatchOrderRequestDto;
 
 import java.util.Map;
@@ -29,8 +30,8 @@ public class MatchClient {
 
 
     // 주문 생성
-    public void sendOrder(MatchOrderRequestDto dto) {
-        restTemplate.postForObject(matchServerUrl + "/internal/orders", dto, Void.class);
+    public MatchResultDto sendOrder(MatchOrderRequestDto dto) {
+        return restTemplate.postForObject(matchServerUrl + "/internal/orders", dto, MatchResultDto.class);
     }
 
 

--- a/server/main/src/main/java/server/main/order/dto/MatchResultDto.java
+++ b/server/main/src/main/java/server/main/order/dto/MatchResultDto.java
@@ -1,0 +1,22 @@
+package server.main.order.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import server.main.order.entity.OrderStatus;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchResultDto {
+    private Long orderId; // 요청 수량 id
+    private Long tokenId; // 토큰 id
+    private OrderStatus finalStatus; // 최종상태
+    private Long filledQuantity; // 체결 된 수량
+    private Long remainingQuantity;
+    private List <TradeExecutionDto> executions; // 체결 목록
+}

--- a/server/main/src/main/java/server/main/order/dto/TradeExecutionDto.java
+++ b/server/main/src/main/java/server/main/order/dto/TradeExecutionDto.java
@@ -1,0 +1,17 @@
+package server.main.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TradeExecutionDto {
+    private Long counterOrderId; // 체결된 상대 주문 ID
+    private Long counterMemberId; // 체결된 상대 멤버 ID
+    private Long tradePrice; // 체결가
+    private Long tradeQuantity; // 체결 수량
+}

--- a/server/match/src/main/java/server/match/order/controller/OrderController.java
+++ b/server/match/src/main/java/server/match/order/controller/OrderController.java
@@ -1,0 +1,36 @@
+package server.match.order.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import server.match.order.dto.MatchOrderRequestDto;
+import server.match.order.dto.MatchResultDto;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/internal/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    // TODO: 매칭 서비스 주입 예정
+
+    @PostMapping
+    public ResponseEntity<MatchResultDto> order(@RequestBody MatchOrderRequestDto dto) {
+        // TODO: 실제 매칭 로직 구현 예정
+        // 현재는 계약 정의 단계이므로 체결 없음(OPEN) 상태로 반환
+        MatchResultDto result = MatchResultDto.builder()
+                .orderId(dto.getOrderId())
+                .tokenId(dto.getTokenId())
+                .finalStatus(server.match.order.entity.OrderStatus.OPEN)
+                .filledQuantity(0L)
+                .remainingQuantity(dto.getOrderQuantity())
+                .executions(List.of())
+                .build();
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/server/match/src/main/java/server/match/order/dto/MatchOrderRequestDto.java
+++ b/server/match/src/main/java/server/match/order/dto/MatchOrderRequestDto.java
@@ -1,0 +1,20 @@
+package server.match.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import server.match.order.entity.OrderType;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchOrderRequestDto {
+    private Long orderId;
+    private Long tokenId;
+    private Long memberId;
+    private OrderType orderType;   // BUY, SELL
+    private Long orderPrice;
+    private Long orderQuantity;
+}

--- a/server/match/src/main/java/server/match/order/dto/MatchResultDto.java
+++ b/server/match/src/main/java/server/match/order/dto/MatchResultDto.java
@@ -1,0 +1,22 @@
+package server.match.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import server.match.order.entity.OrderStatus;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchResultDto {
+    private Long orderId;                       // 요청 주문 ID
+    private Long tokenId;                       // 토큰 ID
+    private OrderStatus finalStatus;            // 최종 상태 (OPEN, PARTIAL, FILLED)
+    private Long filledQuantity;                // 체결된 수량
+    private Long remainingQuantity;             // 남은 수량
+    private List<TradeExecutionDto> executions; // 체결 목록
+}

--- a/server/match/src/main/java/server/match/order/dto/TradeExecutionDto.java
+++ b/server/match/src/main/java/server/match/order/dto/TradeExecutionDto.java
@@ -1,0 +1,17 @@
+package server.match.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TradeExecutionDto {
+    private Long counterOrderId;   // 체결된 상대 주문 ID
+    private Long counterMemberId;  // 체결된 상대 멤버 ID
+    private Long tradePrice;       // 체결가
+    private Long tradeQuantity;    // 체결 수량
+}

--- a/server/match/src/main/java/server/match/order/entity/OrderStatus.java
+++ b/server/match/src/main/java/server/match/order/entity/OrderStatus.java
@@ -1,0 +1,10 @@
+package server.match.order.entity;
+
+public enum OrderStatus {
+    OPEN,       // 접수
+    PENDING,    // 대기
+    PARTIAL,    // 부분 체결
+    FILLED,     // 전체 체결
+    CANCELLED,  // 취소
+    FAILED      // 실패
+}

--- a/server/match/src/main/java/server/match/order/entity/OrderType.java
+++ b/server/match/src/main/java/server/match/order/entity/OrderType.java
@@ -1,0 +1,6 @@
+package server.match.order.entity;
+
+public enum OrderType {
+    BUY,
+    SELL
+}


### PR DESCRIPTION
  - Main/Match 서버에 TradeExecutionDto, MatchResultDto 추가
  - Match 서버에 OrderType, OrderStatus enum 추가
  - Match 서버에 POST /internal/orders 엔드포인트 스텁 추가
  - MatchClient.sendOrder() 반환타입 void → MatchResultDto 변경