### PR TITLE
feat: align watchlist UI with asset ids

### DIFF
--- a/client/web/src/context/AppContext.jsx
+++ b/client/web/src/context/AppContext.jsx
@@ -7,7 +7,7 @@ const AppContext = createContext(null);
 
 export function AppProvider({ children }) {
   const [user, setUser]               = useState(null);
-  const [watchlist, setWatchlist]     = useState(['SEOULST', 'SONGDORE']);
+  const [watchlist, setWatchlist]     = useState([]);
   const [tokens, setTokens]           = useState(INITIAL_TOKENS);
   const [disclosures, setDisclosures] = useState(ADMIN_DISCLOSURES);
   const [notices, setNotices]         = useState(ADMIN_NOTICES);
@@ -66,9 +66,9 @@ export function AppProvider({ children }) {
     setUser(null);
   }
 
-  function toggleWatchlist(id) {
+  function toggleWatchlist(assetId) {
     setWatchlist(prev =>
-      prev.includes(id) ? prev.filter(i => i !== id) : [...prev, id]
+      prev.includes(assetId) ? prev.filter(id => id !== assetId) : [...prev, assetId]
     );
   }
 

--- a/client/web/src/pages/DashboardPage.jsx
+++ b/client/web/src/pages/DashboardPage.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Heart } from "lucide-react";
-import { TOKENS, TREND_DATA } from "../data/mock.js";
+import { TREND_DATA } from "../data/mock.js";
 import { useApp } from "../context/AppContext.jsx";
 import { cn } from "../lib/utils.js";
 import { ResponsiveContainer, LineChart, Line, Tooltip } from "recharts";
@@ -12,7 +12,7 @@ const API = 'http://localhost:8080';
 
 export function DashboardPage() {
   const navigate = useNavigate();
-  const { watchlist, toggleWatchlist } = useApp();
+  const { watchlist, toggleWatchlist, tokens } = useApp();
   const [chartFilter, setChartFilter] = useState("전체");
   const [timeRange, setTimeRange] = useState("실시간");
 
@@ -28,15 +28,28 @@ export function DashboardPage() {
   }, []);
 
   // mock 토큰에 backendId 병합 (tokenSymbol 기준 매칭)
-  const mergedTokens = TOKENS.map(t => {
+  const mergedTokens = tokens.map(t => {
     const matched = backendAssets.find(a => a.tokenSymbol === t.symbol);
-    return { ...t, backendId: matched?.assetId ?? null };
+    return { ...t, assetId: matched?.assetId ?? null };
   });
 
-  const [selectedTokenId, setSelectedTokenId] = useState(TOKENS[0].id);
+  const [selectedTokenId, setSelectedTokenId] = useState(tokens[0]?.id ?? null);
+
+  useEffect(() => {
+    if (!mergedTokens.length) return;
+
+    const hasSelectedToken = mergedTokens.some((token) => token.id === selectedTokenId);
+    if (!hasSelectedToken) {
+      setSelectedTokenId(mergedTokens[0].id);
+    }
+  }, [mergedTokens, selectedTokenId]);
 
   const selectedToken =
     mergedTokens.find((t) => t.id === selectedTokenId) || mergedTokens[0];
+  // 토큰이 하나도 없을 때 렌더링 오류 막기
+  if (!selectedToken) {
+    return null;
+  }
 
   const sortedTokens = [...mergedTokens]
     .sort((a, b) => {
@@ -100,7 +113,6 @@ export function DashboardPage() {
                     )}
                     onClick={() => {
                       setSelectedTokenId(t.id);
-                      if (t.backendId) navigate(`/mockup/${t.backendId}`);
                     }}
                   >
                     <td className="py-4">
@@ -108,11 +120,11 @@ export function DashboardPage() {
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
-                            toggleWatchlist(t.id);
+                            toggleWatchlist(t.assetId);
                           }}
                           className={cn(
                             "transition-colors",
-                            watchlist.includes(t.id)
+                            watchlist.includes(t.assetId)
                               ? "text-brand-red"
                               : "text-stone-400 hover:text-brand-red",
                           )}
@@ -120,7 +132,7 @@ export function DashboardPage() {
                           <Heart
                             size={16}
                             fill={
-                              watchlist.includes(t.id) ? "currentColor" : "none"
+                              watchlist.includes(t.assetId) ? "currentColor" : "none"
                             }
                           />
                         </button>
@@ -186,10 +198,10 @@ export function DashboardPage() {
                 </div>
               </div>
               <button
-                onClick={() => toggleWatchlist(selectedToken.id)}
+                onClick={() => toggleWatchlist(selectedToken.assetId)}
                 className={cn(
                   "p-3 rounded-lg transition-colors border",
-                  watchlist.includes(selectedToken.id)
+                  watchlist.includes(selectedToken.assetId)
                     ? "bg-brand-red-light text-brand-red border-brand-red-light"
                     : "bg-stone-100 text-stone-400 border-stone-200 hover:text-brand-red",
                 )}
@@ -197,7 +209,7 @@ export function DashboardPage() {
                 <Heart
                   size={20}
                   fill={
-                    watchlist.includes(selectedToken.id)
+                    watchlist.includes(selectedToken.assetId)
                       ? "currentColor"
                       : "none"
                   }
@@ -237,8 +249,8 @@ export function DashboardPage() {
 
             <button
               onClick={() => {
-                if (selectedToken?.backendId) {
-                  navigate(`/mockup/${selectedToken.backendId}`);
+                if (selectedToken?.assetId) {
+                  navigate(`/mockup/${selectedToken.assetId}`);
                 }
               }}
               className="w-full py-4 rounded-lg bg-stone-800 text-white font-black uppercase tracking-widest hover:bg-stone-700 transition-colors"

--- a/client/web/src/pages/WatchlistPage.jsx
+++ b/client/web/src/pages/WatchlistPage.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Heart, ArrowUp, ArrowDown, LayoutGrid, List, ChevronRight } from 'lucide-react';
-import { TOKENS, MINI_CHART_DATA } from '../data/mock.js';
+import { MINI_CHART_DATA } from '../data/mock.js';
 import { useApp } from '../context/AppContext.jsx';
 import { cn } from '../lib/utils.js';
 import { SearchInput } from '../components/ui/SearchInput.jsx';
@@ -10,19 +10,19 @@ import { MiniChart } from '../components/ui/MiniChart.jsx';
 
 export function WatchlistPage() {
   const navigate = useNavigate();
-  const { watchlist, toggleWatchlist } = useApp();
+  const { watchlist, toggleWatchlist, tokens } = useApp();
   const [viewMode, setViewMode]     = useState('list');
   const [searchQuery, setSearchQuery] = useState('');
 
-  const filteredTokens = TOKENS.filter(token => {
+  const filteredTokens = tokens.filter(token => {
     const matchesSearch = token.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
                          token.symbol.toLowerCase().includes(searchQuery.toLowerCase());
-    return matchesSearch && watchlist.includes(token.id);
+    return matchesSearch && watchlist.includes(token.assetId);
   });
 
-  function handleToggle(id, e) {
+  function handleToggle(assetId, e) {
     e.stopPropagation();
-    toggleWatchlist(id);
+    toggleWatchlist(assetId);
   }
 
   function getMiniChart(id) {
@@ -83,10 +83,10 @@ export function WatchlistPage() {
                   >
                     <td className="px-8 py-6">
                       <button
-                        onClick={e => handleToggle(token.id, e)}
-                        className={cn('transition-colors', watchlist.includes(token.id) ? 'text-brand-red' : 'text-stone-300 hover:text-brand-red')}
+                        onClick={e => handleToggle(token.assetId, e)}
+                        className={cn('transition-colors', watchlist.includes(token.assetId) ? 'text-brand-red' : 'text-stone-300 hover:text-brand-red')}
                       >
-                        <Heart size={20} fill={watchlist.includes(token.id) ? 'currentColor' : 'none'} />
+                        <Heart size={20} fill={watchlist.includes(token.assetId) ? 'currentColor' : 'none'} />
                       </button>
                     </td>
                     <td className="px-4 py-6">
@@ -133,10 +133,10 @@ export function WatchlistPage() {
                 className="bg-white rounded-[32px] border border-stone-200 p-6 hover:shadow-xl transition-all cursor-pointer group relative overflow-hidden"
               >
                 <button
-                  onClick={e => handleToggle(token.id, e)}
-                  className={cn('absolute top-6 right-6 z-10 transition-colors', watchlist.includes(token.id) ? 'text-brand-red' : 'text-stone-300 hover:text-brand-red')}
+                  onClick={e => handleToggle(token.assetId, e)}
+                  className={cn('absolute top-6 right-6 z-10 transition-colors', watchlist.includes(token.assetId) ? 'text-brand-red' : 'text-stone-300 hover:text-brand-red')}
                 >
-                  <Heart size={20} fill={watchlist.includes(token.id) ? 'currentColor' : 'none'} />
+                  <Heart size={20} fill={watchlist.includes(token.assetId) ? 'currentColor' : 'none'} />
                 </button>
 
                 <div className="flex items-center gap-4 mb-6">


### PR DESCRIPTION
## 변경 내용

- 관심종목 상태를 assetId 기준으로 정리
- 홈 목록, 우측 상세 패널, 관심 페이지 하트 동작을 같은 기준으로 통일
- 홈 목록 클릭 시 즉시 이동하지 않고 우측 선택 패널이 갱신되도록 수정

## 확인 사항

- 홈 목록 하트와 우측 상세 하트가 같은 상태를 보여주는지
- 관심 페이지에서 해제 시 목록에서 바로 사라지는지
- 거래하기 버튼으로만 상세 페이지 이동하는지

## 참고

- package-lock 변경은 이번 PR에 포함하지 않음