### PR TITLE
feat: integrate public notice and disclosure pages

### DIFF
--- a/client/web/src/pages/DisclosurePage.jsx
+++ b/client/web/src/pages/DisclosurePage.jsx
@@ -1,107 +1,197 @@
-import { useState } from 'react';
+﻿import { useEffect, useState } from 'react';
 import { FileText, Download, Filter, Calendar } from 'lucide-react';
 import { cn } from '../lib/utils.js';
 import { TabSwitcher } from '../components/ui/TabSwitcher.jsx';
 import { SearchInput } from '../components/ui/SearchInput.jsx';
 import { Badge } from '../components/ui/Badge.jsx';
 import { EmptyState } from '../components/ui/EmptyState.jsx';
+import api from '../lib/api.js';
 
-const DISCLOSURES = [
-  { id: 1, title: '2026년 1분기 서울강남빌딩 배당 보고서',        date: '2026.03.18', category: '배당', asset: '서울강남빌딩', desc: '서울강남빌딩의 2026년 1분기 운용 실적 및 배당금 산정 내역 보고서입니다.' },
-  { id: 2, title: '2026년 1분기 송도 리조트 배당 보고서',          date: '2026.03.17', category: '배당', asset: '송도 리조트',  desc: '송도 리조트의 2026년 1분기 운용 실적 및 배당금 산정 내역 보고서입니다.' },
-  { id: 3, title: '2026년 2월 전 종목 배당금 지급 결과 보고서',    date: '2026.03.01', category: '배당', asset: '전체',       desc: '2026년 2월 전 종목 배당금 지급 결과 요약 보고서입니다.' },
-  { id: 4, title: '서울강남빌딩 주요 임대차 계약 갱신 공시',       date: '2026.02.25', category: '일반', asset: '서울강남빌딩', desc: '주요 임차인과의 계약 갱신에 따른 임대 수익 변동 안내입니다.' },
-  { id: 5, title: '아트프라임 펀드 작품 매각 및 수익 분배 안내',   date: '2026.02.10', category: '배당', asset: '아트프라임 펀드', desc: '보유 작품 매각에 따른 특별 배당금 지급 안내 보고서입니다.' },
-];
+const DISCLOSURE_TABS = ['전체', '배당', '일반'];
+const DISCLOSURE_LABEL = {
+  BUILDING: '일반',
+  DIVIDEND: '배당',
+  ETC: '일반',
+};
+
+function formatDate(value) {
+  if (!value) return '-';
+  return new Date(value).toLocaleDateString('ko-KR');
+}
 
 export function DisclosurePage() {
   const [searchQuery, setSearchQuery] = useState('');
-  const [activeTab, setActiveTab]     = useState('전체');
+  const [activeTab, setActiveTab] = useState('전체');
+  const [page, setPage] = useState(0);
+  const [items, setItems] = useState([]);
+  const [totalPages, setTotalPages] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [openingId, setOpeningId] = useState(null);
 
-  const tabs = ['전체', '배당', '일반'];
+  useEffect(() => {
+    let mounted = true;
 
-  const filtered = DISCLOSURES.filter(item => {
-    const matchesTab    = activeTab === '전체' || item.category === activeTab;
-    const matchesSearch = item.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                          item.asset.toLowerCase().includes(searchQuery.toLowerCase());
+    async function loadDisclosures() {
+      setLoading(true);
+      try {
+        const { data } = await api.get('/api/disclosure', {
+          params: { page, size: 10 },
+        });
+
+        if (!mounted) return;
+        setItems(Array.isArray(data?.content) ? data.content : []);
+        setTotalPages(Math.max(data?.totalPages ?? 1, 1));
+      } catch (error) {
+        console.error('[DisclosurePage] 목록 조회 실패:', error);
+        if (!mounted) return;
+        setItems([]);
+        setTotalPages(1);
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadDisclosures();
+    return () => {
+      mounted = false;
+    };
+  }, [page]);
+
+  const filteredItems = items.filter((item) => {
+    const categoryLabel = DISCLOSURE_LABEL[item.disclosureCategory] ?? '일반';
+    const keyword = searchQuery.trim().toLowerCase();
+    const matchesTab = activeTab === '전체' || categoryLabel === activeTab;
+    const matchesSearch =
+      keyword.length === 0 ||
+      String(item.disclosureTitle ?? '').toLowerCase().includes(keyword) ||
+      String(item.assetName ?? '').toLowerCase().includes(keyword);
+
     return matchesTab && matchesSearch;
   });
 
+  async function handleOpenDisclosure(item) {
+    if (!item?.storedName) return;
+
+    setOpeningId(item.disclosureId);
+    try {
+      const response = await api.get(`/api/pdf/view/${item.storedName}`, {
+        responseType: 'blob',
+      });
+      const blobUrl = window.URL.createObjectURL(new Blob([response.data], { type: 'application/pdf' }));
+      window.open(blobUrl, '_blank', 'noopener,noreferrer');
+      window.setTimeout(() => window.URL.revokeObjectURL(blobUrl), 60_000);
+    } catch (error) {
+      console.error('[DisclosurePage] PDF 열기 실패:', error);
+    } finally {
+      setOpeningId(null);
+    }
+  }
+
   return (
-    <div className="max-w-[1000px] mx-auto space-y-8">
-      <div className="flex flex-col md:flex-row md:items-center justify-between gap-6">
+    <div className="mx-auto max-w-[1000px] space-y-8">
+      <div className="flex flex-col justify-between gap-6 md:flex-row md:items-center">
         <div>
-          <h2 className="text-3xl font-black text-stone-800 tracking-tight uppercase">
-            정기공시
+          <h2 className="text-3xl font-black tracking-tight text-stone-800 uppercase">
+            공시
           </h2>
-          <p className="text-sm text-stone-500 font-bold mt-2">
-            자산 운용 및 배당에 관한 공식 보고서를 확인하세요.
+          <p className="mt-2 text-sm font-bold text-stone-500">
+            자산 운용과 배당 관련 공시를 확인하세요.
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <SearchInput value={searchQuery} onChange={setSearchQuery} placeholder="종목명 또는 제목 검색..." />
-          <button className="p-2.5 rounded-2xl bg-stone-100 border border-stone-200 text-stone-400 hover:text-stone-800 transition-all">
+          <SearchInput
+            value={searchQuery}
+            onChange={setSearchQuery}
+            placeholder="종목명 또는 공시 제목 검색"
+          />
+          <button className="rounded-2xl border border-stone-200 bg-stone-100 p-2.5 text-stone-400 transition-all hover:text-stone-800">
             <Filter size={20} />
           </button>
         </div>
       </div>
 
-      <TabSwitcher variant="pill" items={tabs} active={activeTab} onChange={setActiveTab} />
+      <TabSwitcher variant="pill" items={DISCLOSURE_TABS} active={activeTab} onChange={setActiveTab} />
 
       <div className="grid gap-4">
-        {filtered.length > 0 ? (
-          filtered.map(item => (
-            <div key={item.id} className="group bg-white rounded-2xl border border-stone-200 p-6 hover:border-stone-300 hover:shadow-xl transition-all cursor-pointer">
-              <div className="flex flex-col md:flex-row md:items-center justify-between gap-6">
-                <div className="flex items-start gap-6">
-                  <div className="w-20 h-20 rounded-2xl bg-stone-100 border border-stone-200 flex items-center justify-center shrink-0">
-                    <FileText size={28} className="text-stone-400" />
-                  </div>
-                  <div>
-                    <div className="flex items-center gap-3 mb-2">
-                      <Badge variant={item.category === '배당' ? 'buy' : 'muted'}>
-                        {item.category} 공시
-                      </Badge>
-                      <span className="text-[10px] font-bold text-stone-400 flex items-center gap-1">
-                        <Calendar size={12} /> {item.date}
-                      </span>
-                      <span className="text-[10px] font-black text-stone-600 bg-stone-100 px-2 py-0.5 rounded-md">
-                        {item.asset}
-                      </span>
+        {loading ? (
+          <EmptyState message="공시 내역을 불러오는 중입니다." />
+        ) : filteredItems.length > 0 ? (
+          filteredItems.map((item) => {
+            const categoryLabel = DISCLOSURE_LABEL[item.disclosureCategory] ?? '일반';
+            return (
+              <div
+                key={item.disclosureId}
+                className="group cursor-pointer rounded-2xl border border-stone-200 bg-white p-6 transition-all hover:border-stone-300 hover:shadow-xl"
+              >
+                <div className="flex flex-col justify-between gap-6 md:flex-row md:items-center">
+                  <div className="flex items-start gap-6">
+                    <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl border border-stone-200 bg-stone-100">
+                      <FileText size={28} className="text-stone-400" />
                     </div>
-                    <h3 className="text-lg font-bold text-stone-800 group-hover:text-stone-600 transition-colors mb-2">{item.title}</h3>
-                    <p className="text-sm text-stone-500 line-clamp-2 leading-relaxed">{item.desc}</p>
+                    <div>
+                      <div className="mb-2 flex flex-wrap items-center gap-3">
+                        <Badge variant={categoryLabel === '배당' ? 'buy' : 'muted'}>
+                          {categoryLabel} 공시
+                        </Badge>
+                        <span className="flex items-center gap-1 text-[10px] font-bold text-stone-400">
+                          <Calendar size={12} /> {formatDate(item.createdAt)}
+                        </span>
+                        <span className="rounded-md bg-stone-100 px-2 py-0.5 text-[10px] font-black text-stone-600">
+                          {item.assetName ?? '-'}
+                        </span>
+                      </div>
+                      <h3 className="mb-2 text-lg font-bold text-stone-800 transition-colors group-hover:text-stone-600">
+                        {item.disclosureTitle}
+                      </h3>
+                      <p className="line-clamp-2 text-sm leading-relaxed text-stone-500">
+                        {item.disclosureContent}
+                      </p>
+                    </div>
                   </div>
-                </div>
 
-                <div className="flex items-center gap-3 self-end md:self-center">
-                  <div className="hidden md:block h-12 w-px bg-stone-200 mx-2" />
-                  <button className="flex items-center gap-2 px-5 py-3 bg-stone-100 border border-stone-200 rounded-2xl text-xs font-black text-stone-500 hover:bg-stone-800 hover:text-white hover:border-stone-800 transition-all">
-                    <FileText size={16} className="text-brand-red" />
-                    보고서 보기
-                    <Download size={14} className="ml-1" />
-                  </button>
+                  <div className="flex items-center gap-3 self-end md:self-center">
+                    <div className="mx-2 hidden h-12 w-px bg-stone-200 md:block" />
+                    <button
+                      type="button"
+                      onClick={() => handleOpenDisclosure(item)}
+                      disabled={!item.storedName || openingId === item.disclosureId}
+                      className={cn(
+                        'flex items-center gap-2 rounded-2xl border px-5 py-3 text-xs font-black transition-all',
+                        item.storedName
+                          ? 'border-stone-200 bg-stone-100 text-stone-500 hover:border-stone-800 hover:bg-stone-800 hover:text-white'
+                          : 'cursor-not-allowed border-stone-200 bg-stone-50 text-stone-300',
+                      )}
+                    >
+                      <FileText size={16} className={cn(item.storedName ? 'text-brand-red' : 'text-stone-300')} />
+                      {openingId === item.disclosureId ? '열는 중...' : item.originName ? '첨부 공시 보기' : '첨부 파일 없음'}
+                      <Download size={14} className="ml-1" />
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))
+            );
+          })
         ) : (
           <EmptyState message="공시 내역이 없습니다." />
         )}
       </div>
 
       <div className="flex justify-center gap-2">
-        {[1, 2].map(p => (
+        {Array.from({ length: totalPages }, (_, index) => index).map((value) => (
           <button
-            key={p}
+            key={value}
+            type="button"
+            onClick={() => setPage(value)}
             className={cn(
-              'w-10 h-10 rounded-xl font-bold text-xs transition-all',
-              p === 1
+              'h-10 w-10 rounded-xl text-xs font-bold transition-all',
+              value === page
                 ? 'bg-stone-800 text-white shadow-lg'
-                : 'bg-white border border-stone-200 text-stone-400 hover:text-stone-800 hover:bg-stone-100'
+                : 'border border-stone-200 bg-white text-stone-400 hover:bg-stone-100 hover:text-stone-800',
             )}
           >
-            {p}
+            {value + 1}
           </button>
         ))}
       </div>

--- a/client/web/src/pages/NoticePage.jsx
+++ b/client/web/src/pages/NoticePage.jsx
@@ -1,87 +1,129 @@
-import { useState } from 'react';
-import { Bell, ChevronRight, Filter, FileText, Download, TrendingUp } from 'lucide-react';
+﻿import { useEffect, useState } from 'react';
+import { Bell, ChevronRight, Filter, LoaderCircle } from 'lucide-react';
 import { cn } from '../lib/utils.js';
 import { TabSwitcher } from '../components/ui/TabSwitcher.jsx';
 import { SearchInput } from '../components/ui/SearchInput.jsx';
 import { Badge } from '../components/ui/Badge.jsx';
 import { EmptyState } from '../components/ui/EmptyState.jsx';
+import api from '../lib/api.js';
 
-const NOTICES = [
-  { id: 1, title: '3월 21일 서비스 점검 및 시스템 고도화 안내',   date: '2026.03.20', category: '시스템', important: true,  desc: '안정적인 서비스 제공을 위해 시스템 점검이 진행될 예정입니다.' },
-  { id: 3, title: '신규 STO 자산 상장 안내 (강남 오피스 빌딩 A)', date: '2026.03.18', category: '일반',   important: false, desc: '새로운 부동산 STO 자산이 상장되었습니다.' },
-  { id: 5, title: '개인정보 처리방침 개정 안내',                   date: '2026.03.15', category: '일반',   important: false, desc: '개인정보 처리방침이 일부 개정되었습니다.' },
-  { id: 6, title: 'STONE 플랫폼 베타 서비스 오픈 이벤트',          date: '2026.03.10', category: '일반',   important: true,  desc: '베타 서비스 오픈 기념 다양한 이벤트를 확인하세요.' },
-  { id: 7, title: '보안 강화를 위한 2단계 인증(2FA) 설정 권고',   date: '2026.03.05', category: '시스템', important: false, desc: '안전한 거래를 위해 2단계 인증을 설정해주세요.' },
-];
+const NOTICE_TABS = ['전체', '일반', '시스템'];
+const NOTICE_LABEL = {
+  GENERAL: '일반',
+  SYSTEM: '시스템',
+};
+
+function formatDate(value) {
+  if (!value) return '-';
+  return new Date(value).toLocaleDateString('ko-KR');
+}
 
 export function NoticePage() {
-  const [activeTab, setActiveTab]           = useState('전체');
-  const [searchQuery, setSearchQuery]       = useState('');
+  const [activeTab, setActiveTab] = useState('전체');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [page, setPage] = useState(0);
+  const [items, setItems] = useState([]);
+  const [totalPages, setTotalPages] = useState(1);
+  const [loading, setLoading] = useState(false);
   const [selectedNotice, setSelectedNotice] = useState(null);
+  const [detailLoading, setDetailLoading] = useState(false);
 
-  const tabs = ['전체', '일반', '시스템'];
+  useEffect(() => {
+    let mounted = true;
 
-  const filtered = NOTICES.filter(n => {
-    const matchesTab    = activeTab === '전체' || n.category === activeTab;
-    const matchesSearch = n.title.toLowerCase().includes(searchQuery.toLowerCase());
+    async function loadNotices() {
+      setLoading(true);
+      try {
+        const { data } = await api.get('/api/notice', {
+          params: { page, size: 10 },
+        });
+
+        if (!mounted) return;
+        setItems(Array.isArray(data?.content) ? data.content : []);
+        setTotalPages(Math.max(data?.totalPages ?? 1, 1));
+      } catch (error) {
+        console.error('[NoticePage] 목록 조회 실패:', error);
+        if (!mounted) return;
+        setItems([]);
+        setTotalPages(1);
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadNotices();
+    return () => {
+      mounted = false;
+    };
+  }, [page]);
+
+  const filteredItems = items.filter((item) => {
+    const typeLabel = NOTICE_LABEL[item.noticeType] ?? '일반';
+    const keyword = searchQuery.trim().toLowerCase();
+    const matchesTab = activeTab === '전체' || typeLabel === activeTab;
+    const matchesSearch =
+      keyword.length === 0 ||
+      String(item.noticeTitle ?? '').toLowerCase().includes(keyword) ||
+      String(item.noticeContent ?? '').toLowerCase().includes(keyword);
+
     return matchesTab && matchesSearch;
   });
 
-  // 상세 보기
+  async function handleSelectNotice(notice) {
+    setDetailLoading(true);
+    try {
+      const { data } = await api.get(`/api/notice/${notice.noticeId}`);
+      setSelectedNotice({
+        noticeId: notice.noticeId,
+        noticeType: data.noticeType,
+        noticeTitle: data.noticeTitle,
+        noticeContent: data.noticeContent,
+        createdAt: data.createdAt,
+      });
+    } catch (error) {
+      console.error('[NoticePage] 상세 조회 실패:', error);
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
   if (selectedNotice) {
+    const typeLabel = NOTICE_LABEL[selectedNotice.noticeType] ?? '일반';
     return (
-      <div className="max-w-[800px] mx-auto space-y-8">
+      <div className="mx-auto max-w-[800px] space-y-8">
         <button
+          type="button"
           onClick={() => setSelectedNotice(null)}
-          className="flex items-center gap-2 text-stone-400 hover:text-stone-800 transition-colors font-bold text-sm"
+          className="flex items-center gap-2 text-sm font-bold text-stone-400 transition-colors hover:text-stone-800"
         >
           <ChevronRight className="rotate-180" size={18} /> 목록으로 돌아가기
         </button>
 
-        <div className="bg-white rounded-2xl border border-stone-200 overflow-hidden shadow-sm">
-          <div className="p-8 border-b border-stone-200">
-            <div className="flex items-center gap-3 mb-4">
-              <Badge variant={selectedNotice.category !== '시스템' && selectedNotice.important ? 'gold' : 'muted'}>
-                {selectedNotice.category}
-              </Badge>
-              <span className="text-[10px] font-bold text-stone-400 font-mono">
-                {selectedNotice.date}
+        <div className="overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-sm">
+          <div className="border-b border-stone-200 p-8">
+            <div className="mb-4 flex items-center gap-3">
+              <Badge variant={typeLabel === '시스템' ? 'muted' : 'gold'}>{typeLabel}</Badge>
+              <span className="font-mono text-[10px] font-bold text-stone-400">
+                {formatDate(selectedNotice.createdAt)}
               </span>
             </div>
-            <h2 className="text-2xl font-black text-stone-800 leading-tight">
-              {selectedNotice.title}
+            <h2 className="text-2xl font-black leading-tight text-stone-800">
+              {selectedNotice.noticeTitle}
             </h2>
           </div>
 
-          <div className="p-8 space-y-6">
-            <div className="text-stone-500 leading-relaxed font-medium">
-              {selectedNotice.desc}
-              <br /><br />
-              안녕하세요, STONE입니다.<br /><br />
-              항상 저희 서비스를 이용해 주시는 고객님께 깊은 감사의 말씀을 드립니다.
-              본 공지사항을 통해 안내드리는 내용을 확인하시어 서비스 이용에 참고하시기 바랍니다.
-              <br /><br />
-              [주요 내용]<br />
-              - 일시: {selectedNotice.date}<br />
-              - 대상: 전체 서비스 이용자<br />
-              - 상세: {selectedNotice.desc}
-              <br /><br />
-              더욱 안정적이고 편리한 서비스를 제공하기 위해 최선을 다하겠습니다.
-              감사합니다.
+          <div className="space-y-6 p-8">
+            <div className="whitespace-pre-wrap leading-relaxed text-stone-600">
+              {selectedNotice.noticeContent}
             </div>
 
-            <div className="pt-8 border-t border-stone-200 flex items-center justify-between">
-              <div className="flex items-center gap-4">
-                <button className="flex items-center gap-2 px-4 py-2 rounded-xl bg-stone-100 text-stone-500 text-xs font-bold hover:bg-stone-200 transition-all">
-                  <FileText size={14} /> 첨부파일.pdf
-                </button>
-                <button className="p-2 rounded-xl bg-stone-100 text-stone-400 hover:text-stone-600 transition-all">
-                  <Download size={18} />
-                </button>
-              </div>
+            <div className="flex items-center justify-end border-t border-stone-200 pt-8">
               <button
+                type="button"
                 onClick={() => setSelectedNotice(null)}
-                className="px-6 py-2 rounded-xl bg-stone-800 text-white text-xs font-black uppercase tracking-widest shadow-lg hover:bg-black transition-all"
+                className="rounded-xl bg-stone-800 px-6 py-2 text-xs font-black uppercase tracking-widest text-white shadow-lg transition-all hover:bg-black"
               >
                 확인 완료
               </button>
@@ -92,64 +134,73 @@ export function NoticePage() {
     );
   }
 
-  // 목록
   return (
-    <div className="max-w-[1000px] mx-auto space-y-8">
-      <div className="flex flex-col md:flex-row md:items-center justify-between gap-6">
+    <div className="mx-auto max-w-[1000px] space-y-8">
+      <div className="flex flex-col justify-between gap-6 md:flex-row md:items-center">
         <div>
-          <h2 className="text-3xl font-black text-stone-800 tracking-tight uppercase">
+          <h2 className="text-3xl font-black tracking-tight text-stone-800 uppercase">
             공지사항
           </h2>
-          <p className="text-sm text-stone-500 font-bold mt-2">
-            STONE 플랫폼의 새로운 소식을 전해드립니다.
+          <p className="mt-2 text-sm font-bold text-stone-500">
+            서비스 운영과 점검 관련 안내를 확인하세요.
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <SearchInput value={searchQuery} onChange={setSearchQuery} placeholder="제목 검색..." />
-          <button className="p-2.5 rounded-2xl bg-stone-100 border border-stone-200 text-stone-400 hover:text-stone-800 transition-all">
+          <SearchInput value={searchQuery} onChange={setSearchQuery} placeholder="공지 제목 검색" />
+          <button className="rounded-2xl border border-stone-200 bg-stone-100 p-2.5 text-stone-400 transition-all hover:text-stone-800">
             <Filter size={20} />
           </button>
         </div>
       </div>
 
-      <TabSwitcher variant="pill" items={tabs} active={activeTab} onChange={setActiveTab} />
+      <TabSwitcher variant="pill" items={NOTICE_TABS} active={activeTab} onChange={setActiveTab} />
 
-      <div className="bg-white rounded-2xl border border-stone-200 overflow-hidden shadow-sm">
+      <div className="overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-sm">
         <div className="divide-y divide-stone-100">
-          {filtered.length > 0 ? (
-            filtered.map(notice => (
-              <div
-                key={notice.id}
-                onClick={() => setSelectedNotice(notice)}
-                className="group p-6 hover:bg-stone-50 transition-all cursor-pointer"
-              >
-                <div className="flex items-start justify-between gap-6">
-                  <div className="flex items-start gap-6">
-                    <div className={cn(
-                      'w-12 h-12 rounded-2xl flex items-center justify-center transition-all shrink-0',
-                      notice.important
-                        ? 'bg-stone-800 text-white shadow-lg'
-                        : 'bg-stone-100 text-stone-400 group-hover:bg-stone-200'
-                    )}>
-                      {notice.category === '배당' ? <TrendingUp size={20} /> : <Bell size={20} />}
-                    </div>
-                    <div>
-                      <div className="flex items-center gap-3 mb-1">
-                        <Badge variant={notice.category !== '시스템' && notice.important ? 'gold' : 'muted'}>
-                          {notice.category}
-                        </Badge>
-                        <span className="text-[10px] font-bold text-stone-400 font-mono">{notice.date}</span>
+          {loading ? (
+            <EmptyState message="공지사항을 불러오는 중입니다." className="m-4" />
+          ) : filteredItems.length > 0 ? (
+            filteredItems.map((notice) => {
+              const typeLabel = NOTICE_LABEL[notice.noticeType] ?? '일반';
+              return (
+                <div
+                  key={notice.noticeId}
+                  onClick={() => handleSelectNotice(notice)}
+                  className="group cursor-pointer p-6 transition-all hover:bg-stone-50"
+                >
+                  <div className="flex items-start justify-between gap-6">
+                    <div className="flex items-start gap-6">
+                      <div
+                        className={cn(
+                          'flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl transition-all',
+                          typeLabel === '시스템'
+                            ? 'bg-stone-800 text-white shadow-lg'
+                            : 'bg-stone-100 text-stone-400 group-hover:bg-stone-200',
+                        )}
+                      >
+                        <Bell size={20} />
                       </div>
-                      <h3 className="text-base font-bold text-stone-800 group-hover:text-stone-600 transition-colors mb-2">
-                        {notice.title}
-                      </h3>
-                      <p className="text-sm text-stone-500 line-clamp-1">{notice.desc}</p>
+                      <div>
+                        <div className="mb-1 flex items-center gap-3">
+                          <Badge variant={typeLabel === '시스템' ? 'muted' : 'gold'}>{typeLabel}</Badge>
+                          <span className="font-mono text-[10px] font-bold text-stone-400">
+                            {formatDate(notice.createdAt)}
+                          </span>
+                        </div>
+                        <h3 className="mb-2 text-base font-bold text-stone-800 transition-colors group-hover:text-stone-600">
+                          {notice.noticeTitle}
+                        </h3>
+                        <p className="line-clamp-1 text-sm text-stone-500">{notice.noticeContent}</p>
+                      </div>
+                    </div>
+                    <div className="mt-1 flex items-center gap-2 text-stone-400 transition-colors group-hover:text-stone-600">
+                      {detailLoading && selectedNotice === null ? <LoaderCircle size={16} className="animate-spin" /> : null}
+                      <ChevronRight size={20} />
                     </div>
                   </div>
-                  <ChevronRight className="text-stone-400 group-hover:text-stone-600 transition-colors mt-1" size={20} />
                 </div>
-              </div>
-            ))
+              );
+            })
           ) : (
             <EmptyState message="검색 결과가 없습니다." className="m-4" />
           )}
@@ -157,17 +208,19 @@ export function NoticePage() {
       </div>
 
       <div className="flex justify-center gap-2">
-        {[1, 2, 3].map(p => (
+        {Array.from({ length: totalPages }, (_, index) => index).map((value) => (
           <button
-            key={p}
+            key={value}
+            type="button"
+            onClick={() => setPage(value)}
             className={cn(
-              'w-10 h-10 rounded-xl font-bold text-xs transition-all',
-              p === 1
+              'h-10 w-10 rounded-xl text-xs font-bold transition-all',
+              value === page
                 ? 'bg-stone-800 text-white shadow-lg'
-                : 'bg-white border border-stone-200 text-stone-400 hover:text-stone-800 hover:bg-stone-100'
+                : 'border border-stone-200 bg-white text-stone-400 hover:bg-stone-100 hover:text-stone-800',
             )}
           >
-            {p}
+            {value + 1}
           </button>
         ))}
       </div>

--- a/server/main/src/main/java/server/main/disclosure/controller/DisclosureController.java
+++ b/server/main/src/main/java/server/main/disclosure/controller/DisclosureController.java
@@ -5,14 +5,19 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import server.main.disclosure.dto.DisclosureListResponseDTO;
 import server.main.disclosure.dto.DisclosureRegisterDTO;
 import server.main.disclosure.dto.DisclosureUpdateDTO;
 import server.main.disclosure.service.DisclosureService;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,15 +26,20 @@ public class DisclosureController {
 
     private final DisclosureService disclosureService;
 
-    // 공시 내역 조회
-    @GetMapping("/admin/disclosure")
-    public ResponseEntity<Page<DisclosureListResponseDTO>> getDisclosure(@RequestParam(defaultValue = "0") int page,
-                                                                         @RequestParam(defaultValue = "10") int size) {
-        Page<DisclosureListResponseDTO> list = disclosureService.getDisclosureList(page, size);
-        return ResponseEntity.ok(list);
+    @GetMapping("/api/disclosure")
+    public ResponseEntity<Page<DisclosureListResponseDTO>> getPublicDisclosure(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(disclosureService.getPublicDisclosureList(page, size));
     }
 
-    // 공시 등록
+    @GetMapping("/admin/disclosure")
+    public ResponseEntity<Page<DisclosureListResponseDTO>> getDisclosure(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(disclosureService.getDisclosureList(page, size));
+    }
+
     @PostMapping("/admin/disclosure")
     public ResponseEntity<Void> registerDisclosure(@RequestPart DisclosureRegisterDTO dto,
                                                    @RequestPart MultipartFile file) {
@@ -37,7 +47,6 @@ public class DisclosureController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    // 공시 수정
     @PatchMapping("/admin/disclosure/{disclosureId}")
     public ResponseEntity<Void> updateDisclosure(@PathVariable Long disclosureId,
                                                  @RequestPart DisclosureUpdateDTO dto,
@@ -46,7 +55,6 @@ public class DisclosureController {
         return ResponseEntity.ok().build();
     }
 
-    // 공시 삭제
     @DeleteMapping("/admin/disclosure/{disclosureId}")
     public ResponseEntity<Void> deleteDisclosure(@PathVariable Long disclosureId,
                                                  @RequestParam String storedName) {

--- a/server/main/src/main/java/server/main/disclosure/repository/DisclosureRepository.java
+++ b/server/main/src/main/java/server/main/disclosure/repository/DisclosureRepository.java
@@ -1,5 +1,7 @@
 package server.main.disclosure.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,4 +16,6 @@ public interface DisclosureRepository extends JpaRepository<Disclosure, Long> {
     Optional<Disclosure> findByAssetIdAndCategory(@Param("assetId") Long assetId);
 
     List<Disclosure> findAllByAssetId(Long assetId);
+
+    Page<Disclosure> findByDeletedAtIsNull(Pageable pageable);
 }

--- a/server/main/src/main/java/server/main/disclosure/service/DisclosureService.java
+++ b/server/main/src/main/java/server/main/disclosure/service/DisclosureService.java
@@ -6,14 +6,13 @@ import server.main.disclosure.dto.DisclosureListResponseDTO;
 import server.main.disclosure.dto.DisclosureRegisterDTO;
 import server.main.disclosure.dto.DisclosureUpdateDTO;
 
-import java.util.List;
-
 public interface DisclosureService {
-    Long registerAssetDisclosure(String assetName, Long assetId);   // 공시 자동등록(BUILDING)
-    Long registerAllocationDisclosure(int year, int month, String assetName, Long assetId); // 공시 자동등록(DIVIDEND)
-    Long getDisclosureBuilding(Long assetId);       // 자산 건물정보 공시 조회
-    Page<DisclosureListResponseDTO> getDisclosureList(int page, int size); // 공시 전체 조회
-    void registerDisclosure(DisclosureRegisterDTO dto, MultipartFile file);  // 공시 등록 (admin)
-    void updateDisclosure(Long disclosureId, DisclosureUpdateDTO dto, MultipartFile file);     // 공시 수정 (admin)
-    void deleteDisclosure(Long disclosureId,  String storedName);        // 파일 저장명);   // 공시 삭제 (admin)
+    Long registerAssetDisclosure(String assetName, Long assetId);
+    Long registerAllocationDisclosure(int year, int month, String assetName, Long assetId);
+    Long getDisclosureBuilding(Long assetId);
+    Page<DisclosureListResponseDTO> getDisclosureList(int page, int size);
+    Page<DisclosureListResponseDTO> getPublicDisclosureList(int page, int size);
+    void registerDisclosure(DisclosureRegisterDTO dto, MultipartFile file);
+    void updateDisclosure(Long disclosureId, DisclosureUpdateDTO dto, MultipartFile file);
+    void deleteDisclosure(Long disclosureId, String storedName);
 }

--- a/server/main/src/main/java/server/main/disclosure/service/DisclosureServiceImpl.java
+++ b/server/main/src/main/java/server/main/disclosure/service/DisclosureServiceImpl.java
@@ -21,7 +21,6 @@ import server.main.disclosure.repository.DisclosureRepository;
 import server.main.global.error.BusinessException;
 import server.main.global.error.ErrorCode;
 import server.main.global.file.File;
-import server.main.global.file.FileRepository;
 import server.main.global.file.FileService;
 
 import java.util.List;
@@ -31,119 +30,99 @@ import java.util.stream.Collectors;
 @Service
 @Log4j2
 @RequiredArgsConstructor
-public class DisclosureServiceImpl implements DisclosureService{
+public class DisclosureServiceImpl implements DisclosureService {
 
     private final DisclosureRepository disclosureRepository;
     private final DisclosureMapper disclosureMapper;
     private final AssetRepository assetRepository;
     private final FileService fileService;
 
-    // 공시 자동 등록 (BUILDING)
     @Override
     public Long registerAssetDisclosure(String assetName, Long assetId) {
         Disclosure disclosure = disclosureRepository.save(disclosureMapper.toDisclosure(assetName, assetId));
-        log.info("공시 등록내역 확인(BUILDING) : {}", disclosure);
+        log.info("공시 자동 등록(BUILDING): {}", disclosure);
         return disclosure.getDisclosureId();
     }
 
-    // 공시 자동 등록 (DIVIDEND)
     @Override
     public Long registerAllocationDisclosure(int year, int month, String assetName, Long assetId) {
-        Disclosure disclosure = disclosureRepository.save(disclosureMapper.toDisclosureAllocation(year, month, assetName, assetId));
-        log.info("공시 등록내역 확인(DIVIDEND) : {}", disclosure);
+        Disclosure disclosure = disclosureRepository.save(
+                disclosureMapper.toDisclosureAllocation(year, month, assetName, assetId)
+        );
+        log.info("공시 자동 등록(DIVIDEND): {}", disclosure);
         return disclosure.getDisclosureId();
     }
 
-    // 자산 건물정보 공시 조회
     @Override
     public Long getDisclosureBuilding(Long assetId) {
         Disclosure disclosure = disclosureRepository.findByAssetIdAndCategory(assetId)
-                .orElseThrow(() -> new EntityNotFoundException("조회된 공시가 없음"));
+                .orElseThrow(() -> new EntityNotFoundException("조회할 공시가 없습니다."));
         return disclosure.getDisclosureId();
     }
 
-    // 공시 전체 조회
     @Override
     public Page<DisclosureListResponseDTO> getDisclosureList(int page, int size) {
-        // 테이블 연관관계 미설정으로 공시, 자산, 파일테이블 조회하여 키값으로 매핑 (N+1 방지를위해 테이블미리 다 조회 후 조합)
-        // 공시 테이블 먼저 조회
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
         Page<Disclosure> disclosures = disclosureRepository.findAll(pageable);
-
-        // 자산id 추출
-        List<Long> assetIds = disclosures.stream()
-                .map(disclosure -> disclosure.getAssetId())
-                .toList();
-        // 공시ID 추출
-        List<Long> disclosureIds = disclosures.stream()
-                .map(disclosure -> disclosure.getDisclosureId())
-                .toList();
-
-        // 자산 조회 (자산ID를 키값으로 MAP생성)
-        Map<Long, Asset> assetMap = assetRepository.findAllById(assetIds).stream()
-                .collect(Collectors.toMap(
-                        asset -> asset.getAssetId(),
-                        asset -> asset
-                        ));
-
-        // 파일조회 (파일ID를 키값으로 MAP생성)
-        Map<Long, File> fileMap = fileService.getAllocationFile(disclosureIds).stream()
-                .collect(Collectors.toMap(
-                        file -> file.getDisclosureId(),
-                        file -> file
-                ));
-
-        // 자산, 파일 map에서 disclosures의 키값으로 값 추출
-        return disclosures.map(disclosure -> {
-                    Asset asset = assetMap.get(disclosure.getAssetId());
-                    File file = fileMap.get(disclosure.getDisclosureId());
-                    // mapper 호출
-                    return disclosureMapper.toDisclosureListResponseDTO(disclosure, asset, file);
-                });
+        return mapDisclosurePage(disclosures);
     }
 
-    // 공시 등록 (admin)
+    @Override
+    public Page<DisclosureListResponseDTO> getPublicDisclosureList(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<Disclosure> disclosures = disclosureRepository.findByDeletedAtIsNull(pageable);
+        return mapDisclosurePage(disclosures);
+    }
+
+    private Page<DisclosureListResponseDTO> mapDisclosurePage(Page<Disclosure> disclosures) {
+        List<Long> assetIds = disclosures.stream()
+                .map(Disclosure::getAssetId)
+                .toList();
+        List<Long> disclosureIds = disclosures.stream()
+                .map(Disclosure::getDisclosureId)
+                .toList();
+
+        Map<Long, Asset> assetMap = assetRepository.findAllById(assetIds).stream()
+                .collect(Collectors.toMap(Asset::getAssetId, asset -> asset));
+
+        Map<Long, File> fileMap = fileService.getAllocationFile(disclosureIds).stream()
+                .collect(Collectors.toMap(File::getDisclosureId, file -> file));
+
+        return disclosures.map(disclosure -> {
+            Asset asset = assetMap.get(disclosure.getAssetId());
+            File file = fileMap.get(disclosure.getDisclosureId());
+            return disclosureMapper.toDisclosureListResponseDTO(disclosure, asset, file);
+        });
+    }
+
     @Transactional
     @Override
     public void registerDisclosure(DisclosureRegisterDTO dto, MultipartFile file) {
-        // 공시 내용먼저 자장
         Disclosure disclosure = disclosureRepository.save(disclosureMapper.toDisclosureRegister(dto));
-        log.info("공시 저장내역 확인 : {}", disclosure);
-        // 파일 저장
+        log.info("공시 저장: {}", disclosure);
         fileService.saveOrUpdatePdf(file, disclosure.getDisclosureId());
     }
 
-    // 공시 수정 (admin)
     @Transactional
     @Override
     public void updateDisclosure(Long disclosureId, DisclosureUpdateDTO dto, MultipartFile file) {
-        // 이전 공시내역 부터 조회
         Disclosure disclosure = disclosureRepository.findById(disclosureId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUNT_ERROR));
-        //  수정 메서드 호출
         disclosure.updateDisclosure(dto.getDisclosureTitle(), dto.getDisclosureContent(), dto.getDisclosureCategory());
-        log.info("공시 수정내역 확인 : {}", disclosure);
+        log.info("공시 수정: {}", disclosure);
 
-        // pdf파일이 수정됐다면
         if (file != null && !file.isEmpty()) {
-            // pdf 저장 메소드 호출 (여기에 기존파일 삭제로직 들어감)
             fileService.saveOrUpdatePdf(file, disclosureId);
         }
     }
 
-    // 공시 삭제 (admin)
     @Transactional
     @Override
     public void deleteDisclosure(Long disclosureId, String storedName) {
-
-        // 삭제 대상 조회
         Disclosure disclosure = disclosureRepository.findById(disclosureId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUNT_ERROR));
-        // 삭제 처리
         disclosure.softDelete();
-        log.info("공시 삭제내역 확인 : {}", disclosure);
-        // 첨부파일 삭제처리
+        log.info("공시 삭제: {}", disclosure);
         fileService.deleteFile(storedName);
     }
-
 }

--- a/server/main/src/main/java/server/main/notice/controller/NoticeController.java
+++ b/server/main/src/main/java/server/main/notice/controller/NoticeController.java
@@ -5,13 +5,18 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import server.main.notice.dto.NoticeDetailResponseDTO;
 import server.main.notice.dto.NoticeListResponseDTO;
 import server.main.notice.dto.NoticeRegisterDTO;
 import server.main.notice.service.NoticeService;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,40 +24,45 @@ import java.util.List;
 public class NoticeController {
     private final NoticeService noticeService;
 
-    // 공지사항 리스트 조회
-    @GetMapping("/admin/notice")
-    public ResponseEntity<Page<NoticeListResponseDTO>> getNoticeList(@RequestParam(defaultValue = "0")int page,
-                                                                     @RequestParam(defaultValue = "10")int size) {
-        Page<NoticeListResponseDTO> list = noticeService.getNoticeList(page, size);
-        return ResponseEntity.ok(list);
+    @GetMapping("/api/notice")
+    public ResponseEntity<Page<NoticeListResponseDTO>> getPublicNoticeList(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(noticeService.getPublicNoticeList(page, size));
     }
 
-    // 공지사항 상세 조회
+    @GetMapping("/api/notice/{noticeId}")
+    public ResponseEntity<NoticeDetailResponseDTO> getPublicNoticeDetail(@PathVariable Long noticeId) {
+        return ResponseEntity.ok(noticeService.getPublicNoticeDetail(noticeId));
+    }
+
+    @GetMapping("/admin/notice")
+    public ResponseEntity<Page<NoticeListResponseDTO>> getNoticeList(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(noticeService.getNoticeList(page, size));
+    }
+
     @GetMapping("/admin/notice/{noticeId}")
     public ResponseEntity<NoticeDetailResponseDTO> getNoticeDetail(@PathVariable Long noticeId) {
-        NoticeDetailResponseDTO dto = noticeService.getNoticeDetail(noticeId);
-        return ResponseEntity.ok(dto);
+        return ResponseEntity.ok(noticeService.getNoticeDetail(noticeId));
     }
 
-    // 공지사항 등록
     @PostMapping("/admin/notice")
     public ResponseEntity<Void> registerNotice(@RequestBody NoticeRegisterDTO dto) {
         noticeService.registerNotice(dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    // 공지사항 수정
     @PatchMapping("/admin/notice/{noticeId}")
     public ResponseEntity<Void> updateNotice(@PathVariable Long noticeId, @RequestBody NoticeRegisterDTO dto) {
         noticeService.updateNotice(noticeId, dto);
         return ResponseEntity.ok().build();
     }
 
-    // 공지사항 삭제
     @DeleteMapping("/admin/notice/{noticeId}")
     public ResponseEntity<Void> deleteNotice(@PathVariable Long noticeId) {
         noticeService.deleteNotice(noticeId);
         return ResponseEntity.noContent().build();
     }
-
 }

--- a/server/main/src/main/java/server/main/notice/repository/NoticeRepository.java
+++ b/server/main/src/main/java/server/main/notice/repository/NoticeRepository.java
@@ -1,7 +1,10 @@
 package server.main.notice.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.main.notice.entity.Notice;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    Page<Notice> findByDeletedAtIsNull(Pageable pageable);
 }

--- a/server/main/src/main/java/server/main/notice/service/NoticeService.java
+++ b/server/main/src/main/java/server/main/notice/service/NoticeService.java
@@ -2,18 +2,17 @@ package server.main.notice.service;
 
 import org.springframework.data.domain.Page;
 import server.main.admin.dto.AssetRegisterRequestDTO;
-import server.main.asset.entity.Asset;
 import server.main.notice.dto.NoticeDetailResponseDTO;
 import server.main.notice.dto.NoticeListResponseDTO;
 import server.main.notice.dto.NoticeRegisterDTO;
 
-import java.util.List;
-
 public interface NoticeService {
-    void registerAssetNotice(AssetRegisterRequestDTO dto); // 자산 등록 시 자동 공지 등록
-    Page<NoticeListResponseDTO> getNoticeList(int page, int size);    // 공지사항 조회
-    void registerNotice(NoticeRegisterDTO dto);     // 공지사항 등록
-    NoticeDetailResponseDTO getNoticeDetail(Long noticeId);  // 공지사항 상세조회
-    void updateNotice(Long noticeId, NoticeRegisterDTO dto);   // 공지사항 수정 및 삭제
-    void deleteNotice(Long noticeId);   // 공지사항 삭제
+    void registerAssetNotice(AssetRegisterRequestDTO dto);
+    Page<NoticeListResponseDTO> getNoticeList(int page, int size);
+    Page<NoticeListResponseDTO> getPublicNoticeList(int page, int size);
+    void registerNotice(NoticeRegisterDTO dto);
+    NoticeDetailResponseDTO getNoticeDetail(Long noticeId);
+    NoticeDetailResponseDTO getPublicNoticeDetail(Long noticeId);
+    void updateNotice(Long noticeId, NoticeRegisterDTO dto);
+    void deleteNotice(Long noticeId);
 }

--- a/server/main/src/main/java/server/main/notice/service/NoticeServiceImpl.java
+++ b/server/main/src/main/java/server/main/notice/service/NoticeServiceImpl.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import server.main.admin.dto.AssetRegisterRequestDTO;
-import server.main.asset.entity.Asset;
 import server.main.global.error.BusinessException;
 import server.main.global.error.ErrorCode;
 import server.main.notice.dto.NoticeDetailResponseDTO;
@@ -20,37 +19,34 @@ import server.main.notice.entity.Notice;
 import server.main.notice.mapper.NoticeMapper;
 import server.main.notice.repository.NoticeRepository;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Service
 @RequiredArgsConstructor
 @Log4j2
-public class NoticeServiceImpl implements NoticeService{
+public class NoticeServiceImpl implements NoticeService {
 
     private final NoticeRepository noticeRepository;
     private final NoticeMapper noticeMapper;
 
-    // 자산 등록 시 자동 공지 등록
     @Override
     public void registerAssetNotice(AssetRegisterRequestDTO dto) {
         NoticeRegisterAssetDTO noticeRegisterAssetDTO = new NoticeRegisterAssetDTO();
         noticeRegisterAssetDTO.changeNotice(dto);
-        log.info("공지등록 내역 확인 : {} ", noticeRegisterAssetDTO);
+        log.info("공지 등록 자동 생성: {}", noticeRegisterAssetDTO);
         noticeRepository.save(noticeMapper.toNotice(noticeRegisterAssetDTO));
     }
 
-    // 공지사항 조회 (admin)
     @Override
     public Page<NoticeListResponseDTO> getNoticeList(int page, int size) {
-        // 전체조회 (생성일 내림차순)
-        Pageable pageable = PageRequest.of(page,size, Sort.by("createdAt").descending());
-        Page<Notice> notices = noticeRepository.findAll(pageable);
-
-        return notices.map(notice -> noticeMapper.toNoticeAdmin(notice));
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        return noticeRepository.findAll(pageable).map(noticeMapper::toNoticeAdmin);
     }
 
-    // 공지사항 등록 (admin)
+    @Override
+    public Page<NoticeListResponseDTO> getPublicNoticeList(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        return noticeRepository.findByDeletedAtIsNull(pageable).map(noticeMapper::toNoticeAdmin);
+    }
+
     @Override
     public void registerNotice(NoticeRegisterDTO dto) {
         Notice notice = Notice.builder()
@@ -59,41 +55,40 @@ public class NoticeServiceImpl implements NoticeService{
                 .noticeType(dto.getNoticeType())
                 .build();
 
-        log.info("공지사항 저장 : {}", notice);
-        // 공지사항 저장
+        log.info("공지사항 저장: {}", notice);
         noticeRepository.save(notice);
     }
 
-    // 공지사항 상세조회 (admin)
     @Override
     public NoticeDetailResponseDTO getNoticeDetail(Long noticeId) {
         Notice notice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUNT_ERROR));
-        log.info("공지사항 상세조회 : {}", notice);
         return noticeMapper.noticeDetailResponseDTO(notice);
     }
 
-    // 공지사항 수정
+    @Override
+    public NoticeDetailResponseDTO getPublicNoticeDetail(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .filter(item -> item.getDeletedAt() == null)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUNT_ERROR));
+        return noticeMapper.noticeDetailResponseDTO(notice);
+    }
+
     @Transactional
     @Override
     public void updateNotice(Long noticeId, NoticeRegisterDTO dto) {
-        // 수정 대상 조회
         Notice notice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUNT_ERROR));
-        // 수정메서드
         notice.updateNotice(dto.getNoticeContent(), dto.getNoticeTitle(), dto.getNoticeType());
-        log.info("공지사항 수정내역 : {}", notice);
+        log.info("공지사항 수정: {}", notice);
     }
 
-    // 공지사항 삭제
     @Transactional
     @Override
     public void deleteNotice(Long noticeId) {
-        // 삭제 대상 조회
         Notice notice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUNT_ERROR));
-        // 삭제 메서드
         notice.softDelete();
-        log.info("공지사항 삭제내역 : {}", notice);
+        log.info("공지사항 삭제: {}", notice);
     }
 }


### PR DESCRIPTION
## Summary
- 공시 페이지를 mock 데이터 대신 공개 API 기반으로 조회하도록 변경했습니다.
- 공지사항 페이지를 공개 API 기반 목록/상세 조회로 변경했습니다.
- 삭제된 공지/공시는 공개 목록에서 제외되도록 백엔드 공개 조회 API를 추가했습니다.

## Backend
- `GET /api/notice`
- `GET /api/notice/{noticeId}`
- `GET /api/disclosure`

- 공지 공개 목록은 `deletedAt is null` 기준으로 조회하도록 반영했습니다.
- 공시 공개 목록도 `deletedAt is null` 기준으로 조회하도록 반영했습니다.

## Frontend
- `NoticePage`에서 실제 공지 목록과 상세 데이터를 조회하도록 변경했습니다.
- `DisclosurePage`에서 실제 공시 목록을 조회하고, 첨부 PDF가 있으면 열 수 있도록 변경했습니다.
- 검색/탭 필터는 기존 UI 흐름을 유지한 채 실제 응답 데이터 기준으로 동작하도록 맞췄습니다.

## Test
- `client/web`: `npm run build`
- `server/main`: `./gradlew compileJava`
