### PR TITLE
feat: add account password verification flow for order actions

### DIFF
--- a/client/web/src/components/trading/OrderPanel.jsx
+++ b/client/web/src/components/trading/OrderPanel.jsx
@@ -19,6 +19,7 @@ export function OrderPanel({ asset, currentPrice, tokenId, token, wsPendingData 
   const [price, setPrice]         = useState(currentPrice > 0 ? String(currentPrice) : '');
   const [qty, setQty]             = useState('');
   const [amount, setAmount]       = useState('');
+  const [accountPassword, setAccountPassword] = useState('');
   const [submitting, setSubmitting]   = useState(false);
   const [orderMsg, setOrderMsg]       = useState(null); // { type: 'success'|'error', text }
 
@@ -30,6 +31,7 @@ export function OrderPanel({ asset, currentPrice, tokenId, token, wsPendingData 
   const [editingOrderId, setEditingOrderId] = useState(null);
   const [editPrice, setEditPrice]           = useState('');
   const [editQty, setEditQty]               = useState('');
+  const [editAccountPassword, setEditAccountPassword] = useState('');
   const [updateMsg, setUpdateMsg]           = useState(null); // { orderId, type, text }
   const [capacity, setCapacity]             = useState({ availableBalance: 0, availableQuantity: 0 });
 
@@ -83,6 +85,26 @@ export function OrderPanel({ asset, currentPrice, tokenId, token, wsPendingData 
     ? (Number(amount) || 0)
     : numPrice * numQty;
 
+  function isValidAccountPassword(value) {
+    return /^\d{4}$/.test(value);
+  }
+
+  function getUserFriendlyErrorMessage(message, fallback) {
+    if (!message || /^HTTP \d+$/.test(message)) {
+      return fallback;
+    }
+    if (message.includes('비밀번호')) {
+      return '계좌 비밀번호가 올바르지 않습니다. 다시 확인해 주세요.';
+    }
+    if (message.includes('잔고')) {
+      return '주문 가능 금액이 부족합니다. 잔고를 확인해 주세요.';
+    }
+    if (message.includes('수량')) {
+      return '주문 수량을 다시 확인해 주세요.';
+    }
+    return message;
+  }
+
   // 대기 주문 REST 조회
   const fetchPendingOrders = useCallback(async () => {
     if (!isLoggedIn || !token || !tokenId) return;
@@ -134,7 +156,11 @@ export function OrderPanel({ asset, currentPrice, tokenId, token, wsPendingData 
       return;
     }
     if (!Number.isInteger(numPrice) || !Number.isInteger(numQty) || numPrice <= 0 || numQty <= 0) {
-      setOrderMsg({ type: 'error', text: '가격과 수량은 양의 정수만 입력하세요.' });
+      setOrderMsg({ type: 'error', text: '가격과 수량을 올바르게 입력해 주세요.' });
+      return;
+    }
+    if (!isValidAccountPassword(accountPassword)) {
+      setOrderMsg({ type: 'error', text: '계좌 비밀번호 4자리를 입력해 주세요.' });
       return;
     }
     setSubmitting(true);
@@ -150,18 +176,23 @@ export function OrderPanel({ asset, currentPrice, tokenId, token, wsPendingData 
           orderPrice:    numPrice,
           orderQuantity: numQty,
           orderType:     isBuy ? 'BUY' : 'SELL',
+          accountPassword,
         }),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
         throw new Error(err.message || `HTTP ${res.status}`);
       }
-      setOrderMsg({ type: 'success', text: `${isBuy ? '매수' : '매도'} 주문이 접수되었습니다.` });
+      setOrderMsg({ type: 'success', text: `${isBuy ? '매수' : '매도'} 주문이 정상적으로 접수되었습니다.` });
       setQty('');
       setAmount('');
+      setAccountPassword('');
       fetchCapacity();
     } catch (e) {
-      setOrderMsg({ type: 'error', text: e.message || '주문 접수에 실패했습니다.' });
+      setOrderMsg({
+        type: 'error',
+        text: getUserFriendlyErrorMessage(e.message, '주문 접수 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'),
+      });
     } finally {
       setSubmitting(false);
     }
@@ -187,6 +218,7 @@ export function OrderPanel({ asset, currentPrice, tokenId, token, wsPendingData 
     setEditingOrderId(o.orderId);
     setEditPrice(String(o.orderPrice ?? ''));
     setEditQty(String(o.orderQuantity ?? ''));
+    setEditAccountPassword('');
     setUpdateMsg(null);
   }
 
@@ -194,6 +226,7 @@ export function OrderPanel({ asset, currentPrice, tokenId, token, wsPendingData 
     setEditingOrderId(null);
     setEditPrice('');
     setEditQty('');
+    setEditAccountPassword('');
     setUpdateMsg(null);
   }
 
@@ -201,8 +234,12 @@ export function OrderPanel({ asset, currentPrice, tokenId, token, wsPendingData 
   async function handleUpdateOrder(orderId) {
     const p = Number(editPrice);
     const q = Number(editQty);
+    if (!isValidAccountPassword(editAccountPassword)) {
+      setUpdateMsg({ orderId, type: 'error', text: '계좌 비밀번호 4자리를 입력해 주세요.' });
+      return;
+    }
     if (!Number.isInteger(p) || !Number.isInteger(q) || p <= 0 || q <= 0) {
-      setUpdateMsg({ orderId, type: 'error', text: '가격과 수량은 양의 정수만 입력하세요.' });
+      setUpdateMsg({ orderId, type: 'error', text: '가격과 수량을 올바르게 입력해 주세요.' });
       return;
     }
     try {
@@ -212,7 +249,11 @@ export function OrderPanel({ asset, currentPrice, tokenId, token, wsPendingData 
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({ updatePrice: p, updateQuantity: q }),
+        body: JSON.stringify({
+          updatePrice: p,
+          updateQuantity: q,
+          accountPassword: editAccountPassword,
+        }),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
@@ -227,9 +268,16 @@ export function OrderPanel({ asset, currentPrice, tokenId, token, wsPendingData 
         })
       );
       setEditingOrderId(null);
+      setEditPrice('');
+      setEditQty('');
+      setEditAccountPassword('');
       setUpdateMsg(null);
     } catch (e) {
-      setUpdateMsg({ orderId, type: 'error', text: e.message || '수정에 실패했습니다.' });
+      setUpdateMsg({
+        orderId,
+        type: 'error',
+        text: getUserFriendlyErrorMessage(e.message, '주문 수정 중 오류가 발생했습니다. 다시 시도해 주세요.'),
+      });
     }
   }
 
@@ -362,6 +410,20 @@ export function OrderPanel({ asset, currentPrice, tokenId, token, wsPendingData 
                                 className="flex-1 bg-transparent text-[11px] font-mono font-bold outline-none text-right text-stone-800"
                               />
                               <span className="text-[11px] font-bold text-stone-400">주</span>
+                            </div>
+                          </div>
+                          <div className="space-y-1">
+                            <label className="text-[10px] font-bold text-stone-400">계좌 비밀번호</label>
+                            <div className="flex items-center gap-2 bg-white border border-stone-300 rounded-md px-3 py-2">
+                              <input
+                                type="password"
+                                inputMode="numeric"
+                                maxLength={4}
+                                value={editAccountPassword}
+                                onChange={e => setEditAccountPassword(e.target.value.replace(/\D/g, '').slice(0, 4))}
+                                placeholder="숫자 4자리"
+                                className="flex-1 bg-transparent text-[11px] font-mono font-bold outline-none text-right text-stone-800 placeholder-stone-400"
+                              />
                             </div>
                           </div>
                           <div className="flex justify-between text-[11px] font-bold border-t border-stone-200 pt-1.5">
@@ -525,6 +587,21 @@ export function OrderPanel({ asset, currentPrice, tokenId, token, wsPendingData 
             )}
 
             {/* 비율 버튼 */}
+            <div className="space-y-1.5">
+              <label className="text-[10px] font-bold text-stone-400">계좌 비밀번호</label>
+              <div className="flex items-center gap-2 bg-stone-200 border border-stone-200 rounded-md px-4 py-2.5">
+                <input
+                  type="password"
+                  inputMode="numeric"
+                  maxLength={4}
+                  placeholder="숫자 4자리"
+                  value={accountPassword}
+                  onChange={e => setAccountPassword(e.target.value.replace(/\D/g, '').slice(0, 4))}
+                  className="flex-1 bg-transparent text-sm font-mono font-bold outline-none text-right pr-2 text-stone-800 placeholder-stone-400"
+                />
+              </div>
+            </div>
+
             <div className="grid grid-cols-4 gap-2">
               {['10%', '25%', '50%', '최대'].map(p => (
                 <button

--- a/client/web/src/lib/api.js
+++ b/client/web/src/lib/api.js
@@ -15,13 +15,18 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
-// 응답 인터셉터 — 401 처리
+// 응답 인터셉터 - 401 처리
 api.interceptors.response.use(
   (response) => response,
   (error) => {
     const token = localStorage.getItem("token");
+    const errorCode = error.response?.data?.errorCode;
+    const shouldLogout =
+      error.response?.status === 401 &&
+      token &&
+      ["UNAUTHORIZED", "INVALID_TOKEN", "TOKEN_EXPIRED"].includes(errorCode);
 
-    if (error.response?.status === 401 && token) {
+    if (shouldLogout) {
       localStorage.removeItem("token");
       window.location.href = "/";
     }

--- a/client/web/src/pages/MockupPage.jsx
+++ b/client/web/src/pages/MockupPage.jsx
@@ -147,6 +147,297 @@ function LoginRequiredModal({ message, onClose }) {
             확인
           </button>
         </div>
+
+        {false && passwordModal && (
+            <OrderPinPadModal
+                title={
+                  passwordModal.action === 'create'
+                      ? `${isBuy ? '매수' : '매도'} 주문 확인`
+                      : passwordModal.action === 'update'
+                          ? '주문 수정 확인'
+                          : '주문 취소 확인'
+                }
+                description={
+                  passwordModal.action === 'create'
+                      ? `${isBuy ? '매수' : '매도'} 주문 내역을 확인한 뒤 계좌 비밀번호를 입력해 주세요.`
+                      : passwordModal.action === 'update'
+                          ? '수정할 주문 내역을 확인한 뒤 계좌 비밀번호를 입력해 주세요.'
+                          : '취소할 주문 내역을 확인한 뒤 계좌 비밀번호를 입력해 주세요.'
+                }
+                password={passwordModal.action === 'create' ? accountPassword : editAccountPassword}
+                errorMessage={
+                  passwordModal.action === 'create'
+                      ? (orderMsg?.type === 'error' ? orderMsg.text : null)
+                      : (updateMsg?.orderId === passwordModal.orderId && updateMsg.type === 'error' ? updateMsg.text : null)
+                }
+                submitting={submitting}
+                onChange={value => {
+                  if (passwordModal.action === 'create') setAccountPassword(value);
+                  else setEditAccountPassword(value);
+                }}
+                onClose={closePasswordModal}
+                onConfirm={handlePasswordConfirm}
+            />
+        )}
+      </div>
+  );
+}
+
+function OrderPinPadModal({
+  title,
+  description,
+  password,
+  errorMessage,
+  submitting,
+  onChange,
+  onClose,
+  onConfirm,
+}) {
+  const masked = password.length > 0 ? '•'.repeat(password.length) : '○ ○ ○ ○';
+  const keys = ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'reset', '0', 'delete'];
+
+  return (
+      <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50" onClick={onClose}>
+        <div
+            className="w-[360px] rounded-2xl border border-stone-200 bg-white p-6 shadow-xl"
+            onClick={e => e.stopPropagation()}
+        >
+          <div className="space-y-2">
+            <h3 className="text-base font-black text-stone-800">{title}</h3>
+            <p className="text-sm font-medium text-stone-500">{description}</p>
+          </div>
+
+          <div className="mt-5 rounded-2xl border border-stone-200 bg-stone-100 px-4 py-5">
+            <div className="text-center font-mono text-2xl font-black tracking-[0.35em] text-stone-800">
+              {masked}
+            </div>
+          </div>
+
+          {errorMessage && (
+              <p className="mt-3 text-center text-[11px] font-bold text-brand-red">{errorMessage}</p>
+          )}
+
+          <div className="mt-5 grid grid-cols-3 gap-2">
+            {keys.map(key => (
+                <button
+                    key={key}
+                    type="button"
+                    onClick={() => {
+                      if (key === 'reset') {
+                        onChange('');
+                        return;
+                      }
+                      if (key === 'delete') {
+                        onChange(password.slice(0, -1));
+                        return;
+                      }
+                      if (password.length >= 4) return;
+                      onChange(`${password}${key}`);
+                    }}
+                    className={cn(
+                        'rounded-xl border py-3 text-sm font-black transition-colors',
+                        key === 'reset' || key === 'delete'
+                            ? 'border-stone-200 bg-stone-100 text-stone-500 hover:bg-stone-200'
+                            : 'border-stone-200 bg-white text-stone-800 hover:bg-stone-100'
+                    )}
+                >
+                  {key === 'reset' ? '초기화' : key === 'delete' ? '지우기' : key}
+                </button>
+            ))}
+          </div>
+
+          <div className="mt-6 rounded-2xl border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+            {description}
+          </div>
+
+          <div className="mt-4 flex gap-2">
+            <button
+                onClick={onClose}
+                disabled={submitting}
+                className="flex-1 rounded-xl border border-stone-200 bg-white py-3 text-sm font-black text-stone-500 hover:bg-stone-100 disabled:opacity-50"
+            >
+              취소
+            </button>
+            <button
+                onClick={onConfirm}
+                disabled={submitting || password.length !== 4}
+                className="flex-1 rounded-xl bg-stone-800 py-3 text-sm font-black text-white hover:bg-stone-700 disabled:opacity-50"
+            >
+              {submitting ? '처리 중...' : '확인'}
+            </button>
+          </div>
+        </div>
+
+        {false && passwordModal && (
+            <OrderPinPadModal
+                title={
+                  passwordModal.action === 'create'
+                      ? `${isBuy ? '매수' : '매도'} 주문 확인`
+                      : passwordModal.action === 'update'
+                          ? '주문 수정 확인'
+                          : '주문 취소 확인'
+                }
+                description={
+                  passwordModal.action === 'create'
+                      ? `${isBuy ? '매수' : '매도'} 주문 내역을 확인한 뒤 계좌 비밀번호를 입력해 주세요.`
+                      : passwordModal.action === 'update'
+                          ? '수정할 주문 내역을 확인한 뒤 계좌 비밀번호를 입력해 주세요.'
+                          : '취소할 주문 내역을 확인한 뒤 계좌 비밀번호를 입력해 주세요.'
+                }
+                password={passwordModal.action === 'create' ? accountPassword : editAccountPassword}
+                errorMessage={
+                  passwordModal.action === 'create'
+                      ? (orderMsg?.type === 'error' ? orderMsg.text : null)
+                      : (updateMsg?.orderId === passwordModal.orderId && updateMsg.type === 'error' ? updateMsg.text : null)
+                }
+                submitting={submitting}
+                onChange={value => {
+                  if (passwordModal.action === 'create') setAccountPassword(value);
+                  else setEditAccountPassword(value);
+                }}
+                onClose={closePasswordModal}
+                onConfirm={handlePasswordConfirm}
+            />
+        )}
+      </div>
+  );
+}
+
+function OrderExecutionConfirmModal({
+  title,
+  items,
+  submitting,
+  onClose,
+  onConfirm,
+}) {
+  return (
+      <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/55" onClick={onClose}>
+        <div
+            className="w-[360px] rounded-2xl border border-stone-200 bg-white p-6 shadow-xl"
+            onClick={e => e.stopPropagation()}
+        >
+          <div className="space-y-1">
+            <h3 className="text-base font-black text-stone-800">{title}</h3>
+            <p className="text-sm text-stone-500">주문 내역을 확인한 뒤 최종 진행해 주세요.</p>
+          </div>
+
+          <div className="mt-5 space-y-2 rounded-2xl border border-stone-200 bg-stone-50 p-4">
+            {items.map(item => (
+                <div key={item.label} className="flex items-center justify-between text-sm">
+                  <span className="font-bold text-stone-400">{item.label}</span>
+                  <span className="font-mono font-black text-stone-800">{item.value}</span>
+                </div>
+            ))}
+          </div>
+
+          <div className="mt-6 flex gap-2">
+            <button
+                onClick={onClose}
+                disabled={submitting}
+                className="flex-1 rounded-xl border border-stone-200 bg-white py-3 text-sm font-black text-stone-500 hover:bg-stone-100 disabled:opacity-50"
+            >
+              취소
+            </button>
+            <button
+                onClick={onConfirm}
+                disabled={submitting}
+                className="flex-1 rounded-xl bg-stone-800 py-3 text-sm font-black text-white hover:bg-stone-700 disabled:opacity-50"
+            >
+              {submitting ? '처리 중...' : '최종 확인'}
+            </button>
+          </div>
+        </div>
+      </div>
+  );
+}
+
+function OrderPasswordModal({
+  title,
+  description,
+  password,
+  errorMessage,
+  submitting,
+  onChange,
+  onClose,
+  onConfirm,
+}) {
+  return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+        <div
+            className="w-[360px] rounded-2xl border border-stone-200 bg-white p-6 shadow-xl"
+            onClick={e => e.stopPropagation()}
+        >
+          <div className="space-y-2">
+            <h3 className="text-base font-black text-stone-800">{title}</h3>
+            <p className="text-sm font-medium text-stone-500">{description}</p>
+          </div>
+
+          <div className="mt-5 space-y-2">
+            <label className="text-[11px] font-bold text-stone-400">계좌 비밀번호</label>
+            <div className="flex items-center gap-2 rounded-xl border border-stone-200 bg-stone-100 px-4 py-3">
+              <input
+                  type="password"
+                  inputMode="numeric"
+                  maxLength={4}
+                  autoFocus
+                  value={password}
+                  onChange={e => onChange(e.target.value.replace(/\D/g, '').slice(0, 4))}
+                  placeholder="숫자 4자리"
+                  className="flex-1 bg-transparent text-right font-mono text-sm font-bold text-stone-800 outline-none placeholder-stone-400"
+              />
+            </div>
+            {errorMessage && <p className="text-[11px] font-bold text-brand-red">{errorMessage}</p>}
+          </div>
+
+          <div className="mt-6 flex gap-2">
+            <button
+                onClick={onClose}
+                disabled={submitting}
+                className="flex-1 rounded-xl border border-stone-200 bg-white py-3 text-sm font-black text-stone-500 transition-colors hover:bg-stone-100 disabled:opacity-50"
+            >
+              취소
+            </button>
+            <button
+                onClick={onConfirm}
+                disabled={submitting}
+                className="flex-1 rounded-xl bg-stone-800 py-3 text-sm font-black text-white transition-colors hover:bg-stone-700 disabled:opacity-50"
+            >
+              {submitting ? '처리 중...' : '확인'}
+            </button>
+          </div>
+        </div>
+
+        {false && passwordModal && (
+            <OrderPasswordModal
+                title={
+                  passwordModal.action === 'create'
+                      ? `${isBuy ? '매수' : '매도'} 주문 확인`
+                      : passwordModal.action === 'update'
+                          ? '주문 수정 확인'
+                          : '주문 취소 확인'
+                }
+                description={
+                  passwordModal.action === 'create'
+                      ? '계좌 비밀번호를 입력한 뒤 주문을 진행해 주세요.'
+                      : passwordModal.action === 'update'
+                          ? '계좌 비밀번호를 입력한 뒤 주문 수정을 진행해 주세요.'
+                          : '계좌 비밀번호를 입력한 뒤 주문 취소를 진행해 주세요.'
+                }
+                password={passwordModal.action === 'create' ? accountPassword : editAccountPassword}
+                errorMessage={
+                  passwordModal.action === 'create'
+                      ? (orderMsg?.type === 'error' ? orderMsg.text : null)
+                      : (updateMsg?.orderId === passwordModal.orderId && updateMsg.type === 'error' ? updateMsg.text : null)
+                }
+                submitting={submitting}
+                onChange={value => {
+                  if (passwordModal.action === 'create') setAccountPassword(value);
+                  else setEditAccountPassword(value);
+                }}
+                onClose={closePasswordModal}
+                onConfirm={handlePasswordConfirm}
+            />
+        )}
       </div>
   );
 }
@@ -1013,6 +1304,7 @@ function LoginGateOrderPanel({ currentPrice, isLoggedIn, onLoginRequired, tokenI
   const [inputMode, setInputMode] = useState('qty');
   const [price, setPrice]             = useState(currentPrice > 0 ? String(currentPrice) : '');
   const [qty, setQty]                 = useState('');
+  const [accountPassword, setAccountPassword] = useState('');
 
   // currentPrice 로드 완료 시 가격 필드 자동 세팅 (비어있을 때만)
   useEffect(() => {
@@ -1030,8 +1322,11 @@ function LoginGateOrderPanel({ currentPrice, isLoggedIn, onLoginRequired, tokenI
   const [editingOrderId, setEditingOrderId] = useState(null);
   const [editPrice, setEditPrice]           = useState('');
   const [editQty, setEditQty]               = useState('');
+  const [editAccountPassword, setEditAccountPassword] = useState('');
   const [updateMsg, setUpdateMsg]           = useState(null); // { orderId, type, text }
   const [capacity, setCapacity]             = useState({ availableBalance: 0, availableQuantity: 0 });
+  const [passwordModal, setPasswordModal]   = useState(null); // { action, orderId? }
+  const [confirmModal, setConfirmModal]     = useState(null); // { action, orderId? }
 
   // WS 실시간 업데이트 수신 시 목록 교체 (편집 중인 주문은 유지)
   useEffect(() => {
@@ -1113,6 +1408,50 @@ function LoginGateOrderPanel({ currentPrice, isLoggedIn, onLoginRequired, tokenI
       ? (Number(amount) || 0)
       : numPrice * numQty;
 
+  function isValidAccountPassword(value) {
+    return /^\d{4}$/.test(value);
+  }
+
+  function getApiErrorMessage(error, fallback) {
+    return error?.response?.data?.errorMessage || error?.response?.data?.message || error?.message || fallback;
+  }
+
+  function openPasswordModal(action, orderId = null) {
+    setPasswordModal({ action, orderId });
+    setConfirmModal(null);
+    if (action === 'create') {
+      setAccountPassword('');
+      setOrderMsg(null);
+    } else {
+      setEditAccountPassword('');
+      setUpdateMsg(null);
+    }
+  }
+
+  function closePasswordModal() {
+    setPasswordModal(null);
+    setAccountPassword('');
+    setEditAccountPassword('');
+  }
+
+  function resetOrderAuthFlow() {
+    setPasswordModal(null);
+    setConfirmModal(null);
+    setAccountPassword('');
+    setEditAccountPassword('');
+  }
+
+  async function verifyPasswordBeforeConfirm() {
+    const password = passwordModal?.action === 'create' ? accountPassword : editAccountPassword;
+
+    try {
+      await api.post('/api/myaccount/verify-password', { accountPassword: password });
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, message: getApiErrorMessage(e, '계좌 비밀번호를 다시 확인해 주세요.') };
+    }
+  }
+
   function handleTabClick(side) {
     if (!isLoggedIn && side === 'pending') {
       onLoginRequired('로그인해야 볼 수 있습니다');
@@ -1136,6 +1475,12 @@ function LoginGateOrderPanel({ currentPrice, isLoggedIn, onLoginRequired, tokenI
       setOrderMsg({ type: 'error', text: `호가 단위에 맞지 않습니다. ${numPrice.toLocaleString()}원 근처 호가 단위는 ${tick.toLocaleString()}원입니다.` });
       return;
     }
+    if (false && !isValidAccountPassword(accountPassword)) {
+      setOrderMsg({ type: 'error', text: '계좌 비밀번호 4자리를 입력해 주세요.' });
+      return;
+    }
+    openPasswordModal('create');
+    return;
     setSubmitting(true);
     setOrderMsg(null);
     try {
@@ -1143,24 +1488,64 @@ function LoginGateOrderPanel({ currentPrice, isLoggedIn, onLoginRequired, tokenI
         orderPrice:    numPrice,
         orderQuantity: numQty,
         orderType:     isBuy ? 'BUY' : 'SELL',
+        accountPassword,
       };
       await api.post(`/api/token/${tokenId}/order`, body);
       setOrderMsg({ type: 'success', text: `${isBuy ? '매수' : '매도'} 주문이 접수되었습니다.` });
       setQty('');
       setAmount('');
+      setAccountPassword('');
       fetchCapacity();
     } catch (e) {
-      setOrderMsg({ type: 'error', text: e.response?.data?.message || e.message || '주문 접수에 실패했습니다.' });
+      setOrderMsg({ type: 'error', text: getApiErrorMessage(e, '주문 접수에 실패했습니다.') });
     } finally {
       setSubmitting(false);
     }
   }
 
-  async function handleCancelOrder(orderId) {
-    if (!token) return;
+  async function submitCreateOrder() {
+    if (!isValidAccountPassword(accountPassword)) {
+      setOrderMsg({ type: 'error', text: '계좌 비밀번호 4자리를 입력해 주세요.' });
+      return;
+    }
+    setSubmitting(true);
+    setOrderMsg(null);
     try {
-      await api.delete(`/api/token/order/cancel/${orderId}`);
+      const body = {
+        orderPrice:    numPrice,
+        orderQuantity: numQty,
+        orderType:     isBuy ? 'BUY' : 'SELL',
+        accountPassword,
+      };
+      await api.post(`/api/token/${tokenId}/order`, body);
+      setOrderMsg({ type: 'success', text: `${isBuy ? '매수' : '매도'} 주문이 접수되었습니다.` });
+      setQty('');
+      setAmount('');
+      resetOrderAuthFlow();
+      fetchCapacity();
+    } catch (e) {
+      setOrderMsg({ type: 'error', text: getApiErrorMessage(e, '주문 접수에 실패했습니다.') });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleCancelOrder(orderId) {
+    openPasswordModal('cancel', orderId);
+  }
+
+  async function submitCancelOrder(orderId) {
+    if (!token) return;
+    if (false && !isValidAccountPassword(editAccountPassword)) {
+      setUpdateMsg({ orderId, type: 'error', text: '계좌 비밀번호 4자리를 입력해 주세요.' });
+      return;
+    }
+    try {
+      await api.delete(`/api/token/order/cancel/${orderId}`, {
+        data: { accountPassword: editAccountPassword },
+      });
       setPendingOrders(prev => prev.filter(o => o.orderId !== orderId));
+      resetOrderAuthFlow();
     } catch (e) {
       console.warn('[OrderPanel] 주문 취소 실패:', e.message);
     }
@@ -1170,6 +1555,7 @@ function LoginGateOrderPanel({ currentPrice, isLoggedIn, onLoginRequired, tokenI
     setEditingOrderId(o.orderId);
     setEditPrice(String(o.orderPrice ?? ''));
     setEditQty(String(o.orderQuantity ?? ''));
+    setEditAccountPassword('');
     setUpdateMsg(null);
   }
 
@@ -1177,12 +1563,17 @@ function LoginGateOrderPanel({ currentPrice, isLoggedIn, onLoginRequired, tokenI
     setEditingOrderId(null);
     setEditPrice('');
     setEditQty('');
+    setEditAccountPassword('');
     setUpdateMsg(null);
   }
 
   async function handleUpdateOrder(orderId) {
     const p = Number(editPrice);
     const q = Number(editQty);
+    if (false && !isValidAccountPassword(editAccountPassword)) {
+      setUpdateMsg({ orderId, type: 'error', text: '계좌 비밀번호 4자리를 입력해 주세요.' });
+      return;
+    }
     if (!Number.isInteger(p) || !Number.isInteger(q) || p <= 0 || q <= 0) {
       setUpdateMsg({ orderId, type: 'error', text: '가격과 수량은 양의 정수만 입력하세요.' });
       return;
@@ -1193,7 +1584,11 @@ function LoginGateOrderPanel({ currentPrice, isLoggedIn, onLoginRequired, tokenI
       return;
     }
     try {
-      await api.put(`/api/token/order/update/${orderId}`, { updatePrice: p, updateQuantity: q });
+      await api.put(`/api/token/order/update/${orderId}`, {
+        updatePrice: p,
+        updateQuantity: q,
+        accountPassword: editAccountPassword,
+      });
       setPendingOrders(prev =>
           prev.map(o => {
             if (o.orderId !== orderId) return o;
@@ -1203,13 +1598,129 @@ function LoginGateOrderPanel({ currentPrice, isLoggedIn, onLoginRequired, tokenI
           })
       );
       setEditingOrderId(null);
+      setEditPrice('');
+      setEditQty('');
+      setEditAccountPassword('');
       setUpdateMsg(null);
     } catch (e) {
-      setUpdateMsg({ orderId, type: 'error', text: e.response?.data?.message || e.message || '수정에 실패했습니다.' });
+      setUpdateMsg({ orderId, type: 'error', text: getApiErrorMessage(e, '수정에 실패했습니다.') });
     }
   }
 
   // ── TickSizePolicy (백엔드와 동일한 로직) ────────────────────
+  async function submitUpdateOrder(orderId) {
+    const p = Number(editPrice);
+    const q = Number(editQty);
+    if (!Number.isInteger(p) || !Number.isInteger(q) || p <= 0 || q <= 0) {
+      setUpdateMsg({ orderId, type: 'error', text: '가격과 수량을 올바르게 입력해 주세요.' });
+      return;
+    }
+    const tick = getTickSize(p);
+    if (p % tick !== 0) {
+      setUpdateMsg({ orderId, type: 'error', text: `호가 단위를 확인해 주세요. 현재 가격의 호가 단위는 ${tick.toLocaleString()}원입니다.` });
+      return;
+    }
+    if (!isValidAccountPassword(editAccountPassword)) {
+      setUpdateMsg({ orderId, type: 'error', text: '계좌 비밀번호 4자리를 입력해 주세요.' });
+      return;
+    }
+    try {
+      await api.put(`/api/token/order/update/${orderId}`, {
+        updatePrice: p,
+        updateQuantity: q,
+        accountPassword: editAccountPassword,
+      });
+      setPendingOrders(prev =>
+          prev.map(o => {
+            if (o.orderId !== orderId) return o;
+            const filledQuantity = Number(o.filledQuantity) || 0;
+            const remainingQuantity = Math.max(q - filledQuantity, 0);
+            return { ...o, orderPrice: p, remainingQuantity, orderQuantity: q };
+          })
+      );
+      setEditingOrderId(null);
+      setEditPrice('');
+      setEditQty('');
+      resetOrderAuthFlow();
+      setUpdateMsg(null);
+    } catch (e) {
+      setUpdateMsg({ orderId, type: 'error', text: getApiErrorMessage(e, '주문 수정에 실패했습니다.') });
+    }
+  }
+
+  async function handlePasswordConfirm() {
+    if (!passwordModal) return;
+    const result = await verifyPasswordBeforeConfirm();
+    if (!result.ok) {
+      if (passwordModal.action === 'create') {
+        setAccountPassword('');
+        setOrderMsg({ type: 'error', text: result.message });
+      } else {
+        setEditAccountPassword('');
+        setUpdateMsg({ orderId: passwordModal.orderId, type: 'error', text: result.message });
+      }
+      return;
+    }
+
+    setPasswordModal(null);
+    setConfirmModal(passwordModal);
+  }
+
+  function getConfirmModalSpec() {
+    if (!confirmModal) return null;
+
+    if (confirmModal.action === 'create') {
+      return {
+        title: `${isBuy ? '매수' : '매도'} 주문 최종 확인`,
+        items: [
+          { label: '구분', value: isBuy ? '매수' : '매도' },
+          { label: '주문가', value: `${numPrice.toLocaleString()}원` },
+          { label: '주문수량', value: `${numQty.toLocaleString()}주` },
+          { label: '총 주문금액', value: `${numAmount.toLocaleString()}원` },
+        ],
+      };
+    }
+
+    const order = pendingOrders.find(o => o.orderId === confirmModal.orderId);
+    const updateTotalAmount = (Number(editPrice) || 0) * (Number(editQty) || 0);
+
+    if (confirmModal.action === 'update') {
+      return {
+        title: '주문 수정 최종 확인',
+        items: [
+          { label: '주문번호', value: String(confirmModal.orderId ?? '-') },
+          { label: '구분', value: order?.orderType === 'BUY' ? '매수' : '매도' },
+          { label: '수정가', value: `${(Number(editPrice) || 0).toLocaleString()}원` },
+          { label: '수정수량', value: `${(Number(editQty) || 0).toLocaleString()}주` },
+          { label: '주문금액', value: `${updateTotalAmount.toLocaleString()}원` },
+        ],
+      };
+    }
+
+    return {
+      title: '주문 취소 최종 확인',
+      items: [
+        { label: '주문번호', value: String(confirmModal.orderId ?? '-') },
+        { label: '구분', value: order?.orderType === 'BUY' ? '매수' : '매도' },
+        { label: '주문가', value: `${Number(order?.orderPrice || 0).toLocaleString()}원` },
+        { label: '잔여수량', value: `${Number(order?.remainingQuantity || 0).toLocaleString()}주` },
+      ],
+    };
+  }
+
+  async function handleConfirmExecution() {
+    if (!confirmModal) return;
+    if (confirmModal.action === 'create') {
+      await submitCreateOrder();
+      return;
+    }
+    if (confirmModal.action === 'update') {
+      await submitUpdateOrder(confirmModal.orderId);
+      return;
+    }
+    await submitCancelOrder(confirmModal.orderId);
+  }
+
   function getTickSize(p) {
     if (p < 100)   return 10;
     if (p < 1000)  return 50;
@@ -1359,6 +1870,20 @@ function LoginGateOrderPanel({ currentPrice, isLoggedIn, onLoginRequired, tokenI
                                         <span className="text-[11px] font-bold text-stone-400">주</span>
                                       </div>
                                     </div>
+                                    <div className="hidden">
+                                      <label className="text-[10px] font-bold text-stone-400">계좌 비밀번호</label>
+                                      <div className="flex items-center gap-2 bg-white border border-stone-300 rounded-md px-3 py-2">
+                                        <input
+                                            type="password"
+                                            inputMode="numeric"
+                                            maxLength={4}
+                                            value={editAccountPassword}
+                                            onChange={e => setEditAccountPassword(e.target.value.replace(/\D/g, '').slice(0, 4))}
+                                            placeholder="숫자 4자리"
+                                            className="flex-1 bg-transparent text-[11px] font-mono font-bold outline-none text-right text-stone-800 placeholder-stone-400"
+                                        />
+                                      </div>
+                                    </div>
                                     <div className="flex justify-between text-[11px] font-bold border-t border-stone-200 pt-1.5">
                                       <span className="text-stone-400">주문금액</span>
                                       <span className="font-mono font-black text-stone-800">{totalAmount.toLocaleString()}원</span>
@@ -1373,7 +1898,7 @@ function LoginGateOrderPanel({ currentPrice, isLoggedIn, onLoginRequired, tokenI
                                     )}
                                     <div className="flex gap-2 pt-1">
                                       <button
-                                          onClick={() => handleUpdateOrder(o.orderId)}
+                                          onClick={() => openPasswordModal('update', o.orderId)}
                                           className="flex-1 py-2 bg-stone-800 border border-stone-800 rounded-md text-[11px] font-black text-white hover:bg-stone-700 transition-all"
                                       >
                                         확인
@@ -1519,6 +2044,21 @@ function LoginGateOrderPanel({ currentPrice, isLoggedIn, onLoginRequired, tokenI
                 )}
 
                 {/* 비율 버튼 */}
+                <div className="hidden">
+                  <label className="text-[10px] font-bold text-stone-400">계좌 비밀번호</label>
+                  <div className="flex items-center gap-2 bg-stone-200 border border-stone-200 rounded-md px-4 py-2.5">
+                    <input
+                        type="password"
+                        inputMode="numeric"
+                        maxLength={4}
+                        placeholder="숫자 4자리"
+                        value={accountPassword}
+                        onChange={e => setAccountPassword(e.target.value.replace(/\D/g, '').slice(0, 4))}
+                        className="flex-1 bg-transparent text-sm font-mono font-bold outline-none text-right pr-2 text-stone-800 placeholder-stone-400"
+                    />
+                  </div>
+                </div>
+
                 <div className="grid grid-cols-4 gap-2">
                   {['10%', '25%', '50%', '최대'].map(p => (
                       <button key={p}
@@ -1588,6 +2128,52 @@ function LoginGateOrderPanel({ currentPrice, isLoggedIn, onLoginRequired, tokenI
               </div>
           )}
         </div>
+
+        {passwordModal && (
+            <OrderPinPadModal
+                title={
+                  passwordModal.action === 'create'
+                      ? `${isBuy ? '매수' : '매도'} 주문 확인`
+                      : passwordModal.action === 'update'
+                          ? '주문 수정 확인'
+                          : '주문 취소 확인'
+                }
+                description={
+                  passwordModal.action === 'create'
+                      ? `${isBuy ? '매수' : '매도'} 주문 내역을 확인한 뒤 계좌 비밀번호를 입력해 주세요.`
+                      : passwordModal.action === 'update'
+                          ? '수정할 주문 내역을 확인한 뒤 계좌 비밀번호를 입력해 주세요.'
+                          : '취소할 주문 내역을 확인한 뒤 계좌 비밀번호를 입력해 주세요.'
+                }
+                password={passwordModal.action === 'create' ? accountPassword : editAccountPassword}
+                errorMessage={
+                  passwordModal.action === 'create'
+                      ? (orderMsg?.type === 'error' ? orderMsg.text : null)
+                      : (updateMsg?.orderId === passwordModal.orderId && updateMsg.type === 'error' ? updateMsg.text : null)
+                }
+                submitting={submitting}
+                onChange={value => {
+                  if (passwordModal.action === 'create') setAccountPassword(value);
+                  else setEditAccountPassword(value);
+                }}
+                onClose={closePasswordModal}
+                onConfirm={handlePasswordConfirm}
+            />
+        )}
+
+        {(() => {
+          const spec = getConfirmModalSpec();
+          if (!spec) return null;
+          return (
+              <OrderExecutionConfirmModal
+                  title={spec.title}
+                  items={spec.items}
+                  submitting={submitting}
+                  onClose={() => setConfirmModal(null)}
+                  onConfirm={handleConfirmExecution}
+              />
+          );
+        })()}
       </div>
   );
 }

--- a/server/main/src/main/java/server/main/myaccount/controller/MyAccountController.java
+++ b/server/main/src/main/java/server/main/myaccount/controller/MyAccountController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import server.main.myaccount.dto.AccountBalanceResponse;
 import server.main.myaccount.dto.DepositRequest;
 import server.main.myaccount.dto.PortfolioResponse;
+import server.main.myaccount.dto.VerifyAccountPasswordRequest;
 import server.main.myaccount.dto.WithdrawRequest;
 import server.main.myaccount.service.MyAccountService;
 
@@ -39,5 +40,11 @@ public class MyAccountController {
     @GetMapping("/portfolio")
     public ResponseEntity<List<PortfolioResponse>> getPortfolio() {
         return ResponseEntity.ok(myAccountService.getPortfolio());
+    }
+
+    @PostMapping("/verify-password")
+    public ResponseEntity<Void> verifyPassword(@RequestBody @Valid VerifyAccountPasswordRequest request) {
+        myAccountService.verifyAccountPassword(request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/server/main/src/main/java/server/main/myaccount/dto/VerifyAccountPasswordRequest.java
+++ b/server/main/src/main/java/server/main/myaccount/dto/VerifyAccountPasswordRequest.java
@@ -1,28 +1,17 @@
-package server.main.order.dto;
+package server.main.myaccount.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import server.main.order.entity.OrderType;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class OrderRequestDto {
-    @NotNull
-    @Positive
-    private Long orderPrice;
-    @NotNull
-    @Positive
-    private Long orderQuantity;
-    @NotNull
-    private OrderType orderType;
+public class VerifyAccountPasswordRequest {
     @NotBlank
     @Pattern(regexp = "\\d{4}", message = "계좌 비밀번호는 4자리 숫자여야 합니다.")
     private String accountPassword;

--- a/server/main/src/main/java/server/main/myaccount/service/MyAccountService.java
+++ b/server/main/src/main/java/server/main/myaccount/service/MyAccountService.java
@@ -3,6 +3,7 @@ package server.main.myaccount.service;
 import server.main.myaccount.dto.AccountBalanceResponse;
 import server.main.myaccount.dto.DepositRequest;
 import server.main.myaccount.dto.PortfolioResponse;
+import server.main.myaccount.dto.VerifyAccountPasswordRequest;
 import server.main.myaccount.dto.WithdrawRequest;
 
 import java.util.List;
@@ -15,5 +16,7 @@ public interface MyAccountService {
     AccountBalanceResponse getBalance();
 
     List<PortfolioResponse> getPortfolio();
+
+    void verifyAccountPassword(VerifyAccountPasswordRequest request);
 
 }

--- a/server/main/src/main/java/server/main/myaccount/service/MyAccountServiceImpl.java
+++ b/server/main/src/main/java/server/main/myaccount/service/MyAccountServiceImpl.java
@@ -2,6 +2,7 @@ package server.main.myaccount.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.main.global.error.BusinessException;
@@ -14,6 +15,7 @@ import server.main.member.repository.MemberTokenHoldingRepository;
 import server.main.myaccount.dto.AccountBalanceResponse;
 import server.main.myaccount.dto.DepositRequest;
 import server.main.myaccount.dto.PortfolioResponse;
+import server.main.myaccount.dto.VerifyAccountPasswordRequest;
 import server.main.myaccount.dto.WithdrawRequest;
 
 import java.util.List;
@@ -26,6 +28,7 @@ public class MyAccountServiceImpl implements MyAccountService{
     private final AccountRepository accountRepository;
     private final MemberBankRepository memberBankRepository;
     private final MemberTokenHoldingRepository memberTokenHoldingRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public void deposit(DepositRequest depositRequest) {
@@ -97,5 +100,19 @@ public class MyAccountServiceImpl implements MyAccountService{
                 .filter(h -> h.getCurrentQuantity() > 0)
                 .map(PortfolioResponse :: from)
                 .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public void verifyAccountPassword(VerifyAccountPasswordRequest request) {
+        Long memberId = ((CustomUserPrincipal) SecurityContextHolder
+                .getContext().getAuthentication().getPrincipal()).getId();
+
+        Account account = accountRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+        if (!passwordEncoder.matches(request.getAccountPassword(), account.getAccountPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
     }
 }

--- a/server/main/src/main/java/server/main/order/controller/OrderController.java
+++ b/server/main/src/main/java/server/main/order/controller/OrderController.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import server.main.order.dto.OrderCapacityResponseDto;
+import server.main.order.dto.CancelOrderRequestDto;
 import server.main.order.dto.OrderRequestDto;
 import server.main.order.dto.PendingOrderResponseDto;
 import server.main.order.dto.UpdateOrderRequestDto;
@@ -65,8 +66,9 @@ public class OrderController {
 
     // 호가 삭제 (soft delete)
     @DeleteMapping("/order/cancel/{orderId}")
-    public ResponseEntity<Void> orderCancel(@PathVariable Long orderId) {
-        orderFacade.cancelOrder(orderId);
+    public ResponseEntity<Void> orderCancel(@PathVariable Long orderId,
+            @Validated @RequestBody CancelOrderRequestDto dto) {
+        orderFacade.cancelOrder(orderId, dto);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/server/main/src/main/java/server/main/order/dto/CancelOrderRequestDto.java
+++ b/server/main/src/main/java/server/main/order/dto/CancelOrderRequestDto.java
@@ -1,28 +1,17 @@
 package server.main.order.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import server.main.order.entity.OrderType;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class OrderRequestDto {
-    @NotNull
-    @Positive
-    private Long orderPrice;
-    @NotNull
-    @Positive
-    private Long orderQuantity;
-    @NotNull
-    private OrderType orderType;
+public class CancelOrderRequestDto {
     @NotBlank
     @Pattern(regexp = "\\d{4}", message = "계좌 비밀번호는 4자리 숫자여야 합니다.")
     private String accountPassword;

--- a/server/main/src/main/java/server/main/order/dto/UpdateOrderRequestDto.java
+++ b/server/main/src/main/java/server/main/order/dto/UpdateOrderRequestDto.java
@@ -1,6 +1,8 @@
 package server.main.order.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import lombok.*;
 
@@ -16,4 +18,8 @@ public class UpdateOrderRequestDto {
     @NotNull
     @Positive
     private Long updateQuantity;
+
+    @NotBlank
+    @Pattern(regexp = "\\d{4}", message = "계좌 비밀번호는 4자리 숫자여야 합니다.")
+    private String accountPassword;
 }

--- a/server/main/src/main/java/server/main/order/service/OrderFacade.java
+++ b/server/main/src/main/java/server/main/order/service/OrderFacade.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import server.main.global.error.BusinessException;
 import server.main.global.util.MatchClient;
 import server.main.order.dto.CancelOrderContext;
+import server.main.order.dto.CancelOrderRequestDto;
 import server.main.order.dto.MatchOrderRequestDto;
 import server.main.order.dto.MatchResultDto;
 import server.main.order.dto.OrderRequestDto;
@@ -61,9 +62,9 @@ public class OrderFacade {
         orderService.processMatchResult(orderId, matchDto.getTokenId(), matchResult);
     }
 
-    public void cancelOrder(Long orderId) {
+    public void cancelOrder(Long orderId, CancelOrderRequestDto dto) {
         // phase 1
-        CancelOrderContext ctx = orderService.validateAndCancelOrder(orderId);
+        CancelOrderContext ctx = orderService.validateAndCancelOrder(orderId, dto);
 
         // match 호출
         try {

--- a/server/main/src/main/java/server/main/order/service/OrderService.java
+++ b/server/main/src/main/java/server/main/order/service/OrderService.java
@@ -27,7 +27,7 @@ public interface OrderService {
     List<PendingOrderResponseDto> getPendingOrders(Long tokenId);
 
     // cancelOrder Phase 1: 검증 + 잔고 복구 + PENDING 전환 → 커밋
-    CancelOrderContext validateAndCancelOrder(Long orderId);
+    CancelOrderContext validateAndCancelOrder(Long orderId, CancelOrderRequestDto dto);
 
     // cancelOrder Phase 2: CANCELLED 최종 전환 → 커밋
     void completeCancelOrder(Long orderId);

--- a/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
+++ b/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,6 +55,7 @@ import server.main.member.repository.BankingRepository;
 import server.main.member.repository.MemberRepository;
 import server.main.member.repository.MemberTokenHoldingRepository;
 import server.main.order.dto.CancelOrderContext;
+import server.main.order.dto.CancelOrderRequestDto;
 import server.main.order.dto.MatchOrderRequestDto;
 import server.main.order.dto.MatchResultDto;
 import server.main.order.dto.OrderCapacityResponseDto;
@@ -99,6 +101,7 @@ public class OrderServiceImpl implements OrderService {
     private final AlarmService alarmService;
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
+    private final PasswordEncoder passwordEncoder;
     private final CommonRepository commonRepository;
     private final PlatformAccountRepository platformAccountRepository;
     private final BankingRepository bankingRepository;
@@ -124,6 +127,7 @@ public class OrderServiceImpl implements OrderService {
 
             Account findMemberAccount = accountRepository.findWithLockByMember(findMember)
                     .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+            validateAccountPassword(findMemberAccount, dto.getAccountPassword());
 
             double chargeRate = getChargeRate();
 
@@ -139,6 +143,10 @@ public class OrderServiceImpl implements OrderService {
 
         // 매도일 경우
         if (OrderType.SELL.equals(dto.getOrderType())) {
+            Account findMemberAccount = accountRepository.findWithLockByMember(findMember)
+                    .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+            validateAccountPassword(findMemberAccount, dto.getAccountPassword());
+
             MemberTokenHolding findMemberHolding = memberTokenHoldingRepository
                     .findWithLockByMemberAndToken(findMember, findToken)
                     .orElseThrow(() -> new BusinessException(INSUFFICIENT_TOKEN_BALANCE));
@@ -545,6 +553,7 @@ public class OrderServiceImpl implements OrderService {
         if (OrderType.BUY.equals(findOrder.getOrderType())) {
             Account findAccount = accountRepository.findWithLockByMember(findOrder.getMember())
                     .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+            validateAccountPassword(findAccount, dto.getAccountPassword());
 
             long oldAmount = Math.multiplyExact(findOrder.getOrderPrice(), findOrder.getRemainingQuantity());
             long oldFee = (long) (oldAmount * (chargeRate / 100));
@@ -561,6 +570,10 @@ public class OrderServiceImpl implements OrderService {
         }
 
         if (OrderType.SELL.equals(findOrder.getOrderType())) {
+            Account findAccount = accountRepository.findWithLockByMember(findOrder.getMember())
+                    .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+            validateAccountPassword(findAccount, dto.getAccountPassword());
+
             MemberTokenHolding tokenHolding = memberTokenHoldingRepository
                     .findWithLockByMemberAndToken(findOrder.getMember(), findOrder.getToken())
                     .orElseThrow(() -> new BusinessException(INSUFFICIENT_TOKEN_BALANCE));
@@ -635,7 +648,7 @@ public class OrderServiceImpl implements OrderService {
     // cancelOrder Phase 1: 검증 + 잔고 복구 + PENDING 전환
     @Transactional
     @Override
-    public CancelOrderContext validateAndCancelOrder(Long orderId) {
+    public CancelOrderContext validateAndCancelOrder(Long orderId, CancelOrderRequestDto dto) {
         Long memberId = ((CustomUserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal())
                 .getId();
 
@@ -652,9 +665,16 @@ public class OrderServiceImpl implements OrderService {
         if (OrderType.BUY.equals(findOrder.getOrderType())) {
             Account findAccount = accountRepository.findWithLockByMember(findOrder.getMember())
                     .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+            validateAccountPassword(findAccount, dto.getAccountPassword());
             long lockedAmount = Math.multiplyExact(findOrder.getOrderPrice(), findOrder.getRemainingQuantity());
             long feeOnLock = (long) (lockedAmount * (getChargeRate() / 100));
             findAccount.cancelOrder(lockedAmount + feeOnLock);
+        }
+
+        if (OrderType.SELL.equals(findOrder.getOrderType())) {
+            Account findAccount = accountRepository.findWithLockByMember(findOrder.getMember())
+                    .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+            validateAccountPassword(findAccount, dto.getAccountPassword());
         }
 
         if (OrderType.SELL.equals(findOrder.getOrderType())) {
@@ -729,5 +749,11 @@ public class OrderServiceImpl implements OrderService {
         Common common = commonRepository.findCommon();
         if (common == null) throw new BusinessException(ENTITY_NOT_FOUNT_ERROR);
         return common.getChargeRate();
+    }
+
+    private void validateAccountPassword(Account account, String rawAccountPassword) {
+        if (!passwordEncoder.matches(rawAccountPassword, account.getAccountPassword())) {
+            throw new BusinessException(INVALID_PASSWORD);
+        }
     }
 }

--- a/server/main/src/main/java/server/main/token/service/TokenServiceImpl.java
+++ b/server/main/src/main/java/server/main/token/service/TokenServiceImpl.java
@@ -176,7 +176,9 @@ public class TokenServiceImpl implements TokenService{
             Long basePrice = basePriceMap.get(tokenId);
             long[] agg = tradeAggMap.getOrDefault(tokenId, new long[]{0L, 0L});
 
-            double fluctuationRate = (basePrice != null && basePrice > 0) ? (currentPrice - basePrice) / basePrice * 100 : 0.0;
+            double fluctuationRate = (basePrice != null && basePrice > 0)
+                    ? ((double) (currentPrice - basePrice) / basePrice) * 100
+                    : 0.0;
 
             return TokenMainResponseDto.builder()
                     .tokenId(tokenId)

--- a/server/main/src/test/java/server/main/order/service/OrderFacadeTest.java
+++ b/server/main/src/test/java/server/main/order/service/OrderFacadeTest.java
@@ -41,6 +41,7 @@ class OrderFacadeTest {
     void createOrder_정상_phase1_match_phase2_순서검증() {
         // given
         OrderRequestDto requestDto = OrderRequestDto.builder()
+                .accountPassword("1234")
                 .orderType(OrderType.BUY)
                 .orderPrice(12000L)
                 .orderQuantity(5L)
@@ -80,6 +81,7 @@ class OrderFacadeTest {
     void createOrder_match실패_보상트랜잭션_호출검증() {
         // given
         OrderRequestDto requestDto = OrderRequestDto.builder()
+                .accountPassword("1234")
                 .orderType(OrderType.BUY)
                 .orderPrice(12000L)
                 .orderQuantity(5L)
@@ -110,6 +112,7 @@ class OrderFacadeTest {
     void updateOrder_정상_phase1_match_phase2_순서검증() {
         // given
         UpdateOrderRequestDto requestDto = UpdateOrderRequestDto.builder()
+                .accountPassword("1234")
                 .updatePrice(13000L)
                 .updateQuantity(8L)
                 .build();
@@ -149,6 +152,7 @@ class OrderFacadeTest {
     void updateOrder_match실패_보상트랜잭션_호출검증() {
         // given
         UpdateOrderRequestDto requestDto = UpdateOrderRequestDto.builder()
+                .accountPassword("1234")
                 .updatePrice(13000L)
                 .updateQuantity(8L)
                 .build();

--- a/server/main/src/test/java/server/main/order/service/OrderServiceImplTest.java
+++ b/server/main/src/test/java/server/main/order/service/OrderServiceImplTest.java
@@ -20,7 +20,13 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+import server.main.admin.entity.Common;
+import server.main.admin.entity.PlatformAccount;
+import server.main.admin.repository.CommonRepository;
+import server.main.admin.repository.PlatformAccountRepository;
+import server.main.admin.repository.PlatformBankingRepository;
 import server.main.blockchain.service.BlockchainOutboxService;
 import server.main.global.error.BusinessException;
 import server.main.global.security.CustomUserPrincipal;
@@ -30,6 +36,7 @@ import server.main.member.entity.Account;
 import server.main.member.entity.Member;
 import server.main.member.entity.MemberTokenHolding;
 import server.main.member.repository.AccountRepository;
+import server.main.member.repository.BankingRepository;
 import server.main.member.repository.MemberRepository;
 import server.main.member.repository.MemberTokenHoldingRepository;
 import server.main.order.dto.MatchOrderRequestDto;
@@ -68,6 +75,12 @@ class OrderServiceImplTest {
     @Mock OrderDuplicatedRepository orderDuplicatedRepository;
     @Mock TradeDuplicatedRepository tradeDuplicatedRepository;
     @Mock ApplicationEventPublisher eventPublisher;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock CommonRepository commonRepository;
+    @Mock PlatformAccountRepository platformAccountRepository;
+    @Mock BankingRepository bankingRepository;
+    @Mock PlatformBankingRepository platformBankingRepository;
+    @Mock PlatformAccount platformAccount;
 
     @InjectMocks
     OrderServiceImpl orderService;
@@ -83,6 +96,12 @@ class OrderServiceImplTest {
         lenient().when(securityContext.getAuthentication()).thenReturn(authentication);
         lenient().when(authentication.getPrincipal()).thenReturn(principal);
         SecurityContextHolder.setContext(securityContext);
+
+        Common common = mock(Common.class);
+        lenient().when(commonRepository.findCommon()).thenReturn(common);
+        lenient().when(common.getChargeRate()).thenReturn(0.0);
+        lenient().when(passwordEncoder.matches(any(CharSequence.class), nullable(String.class))).thenReturn(true);
+        lenient().when(platformAccountRepository.findWithLock()).thenReturn(Optional.of(platformAccount));
     }
 
     // ──────────────── getPendingOrders ────────────────
@@ -169,9 +188,12 @@ class OrderServiceImplTest {
         when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
         when(tokenRepository.findById(TOKEN_ID)).thenReturn(Optional.of(token));
         when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
+        when(account.getAccountPassword()).thenReturn("encoded");
+        when(passwordEncoder.matches("1234", "encoded")).thenReturn(true);
         when(account.getAvailableBalance()).thenReturn(1_000_000L);
 
-        OrderRequestDto dto = OrderRequestDto.builder()
+        OrderRequestDto dto = OrderRequestDto.builder().accountPassword("1234")
+                .accountPassword("1234")
                 .orderType(OrderType.BUY)
                 .orderPrice(12000L)
                 .orderQuantity(5L) // 총 60000 < 잔고 1000000
@@ -202,7 +224,7 @@ class OrderServiceImplTest {
         when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
         when(account.getAvailableBalance()).thenReturn(10_000L); // 잔고 부족
 
-        OrderRequestDto dto = OrderRequestDto.builder()
+        OrderRequestDto dto = OrderRequestDto.builder().accountPassword("1234")
                 .orderType(OrderType.BUY)
                 .orderPrice(12000L)
                 .orderQuantity(5L) // 총 60000 > 잔고 10000
@@ -217,15 +239,17 @@ class OrderServiceImplTest {
     @Test
     void validateAndSaveOrder_매도_토큰미보유_예외발생() {
         // given
+        Account account = mock(Account.class);
         Member member = mock(Member.class);
         Token token = mock(Token.class);
 
         when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
         when(tokenRepository.findById(TOKEN_ID)).thenReturn(Optional.of(token));
+        when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
         when(memberTokenHoldingRepository.findWithLockByMemberAndToken(member, token))
                 .thenReturn(Optional.empty());
 
-        OrderRequestDto dto = OrderRequestDto.builder()
+        OrderRequestDto dto = OrderRequestDto.builder().accountPassword("1234")
                 .orderType(OrderType.SELL)
                 .orderPrice(12000L)
                 .orderQuantity(5L)
@@ -240,17 +264,19 @@ class OrderServiceImplTest {
     @Test
     void validateAndSaveOrder_매도_수량부족_예외발생() {
         // given
+        Account account = mock(Account.class);
         Member member = mock(Member.class);
         Token token = mock(Token.class);
         MemberTokenHolding holding = mock(MemberTokenHolding.class);
 
         when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
         when(tokenRepository.findById(TOKEN_ID)).thenReturn(Optional.of(token));
+        when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
         when(memberTokenHoldingRepository.findWithLockByMemberAndToken(member, token))
                 .thenReturn(Optional.of(holding));
         when(holding.getCurrentQuantity()).thenReturn(3L); // 보유 3주
 
-        OrderRequestDto dto = OrderRequestDto.builder()
+        OrderRequestDto dto = OrderRequestDto.builder().accountPassword("1234")
                 .orderType(OrderType.SELL)
                 .orderPrice(12000L)
                 .orderQuantity(5L) // 요청 5주 > 보유 3주
@@ -265,17 +291,19 @@ class OrderServiceImplTest {
     @Test
     void validateAndSaveOrder_매도_정상접수() {
         // given
+        Account account = mock(Account.class);
         Member member = mock(Member.class);
         Token token = mock(Token.class);
         MemberTokenHolding holding = mock(MemberTokenHolding.class);
 
         when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
         when(tokenRepository.findById(TOKEN_ID)).thenReturn(Optional.of(token));
+        when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
         when(memberTokenHoldingRepository.findWithLockByMemberAndToken(member, token))
                 .thenReturn(Optional.of(holding));
         when(holding.getCurrentQuantity()).thenReturn(10L); // 보유 10주
 
-        OrderRequestDto dto = OrderRequestDto.builder()
+        OrderRequestDto dto = OrderRequestDto.builder().accountPassword("1234")
                 .orderType(OrderType.SELL)
                 .orderPrice(12000L)
                 .orderQuantity(5L) // 요청 5주 <= 보유 10주
@@ -303,6 +331,7 @@ class OrderServiceImplTest {
                 .thenReturn(Optional.of(order));
 
         UpdateOrderRequestDto dto = UpdateOrderRequestDto.builder()
+                .accountPassword("1234")
                 .updatePrice(12000L)
                 .updateQuantity(5L)
                 .build();
@@ -324,6 +353,7 @@ class OrderServiceImplTest {
                 .thenReturn(Optional.of(order));
 
         UpdateOrderRequestDto dto = UpdateOrderRequestDto.builder()
+                .accountPassword("1234")
                 .updatePrice(12000L)
                 .updateQuantity(5L) // filledQuantity(5)와 같음 → 예외
                 .build();
@@ -357,16 +387,17 @@ class OrderServiceImplTest {
         when(account.getAvailableBalance()).thenReturn(0L);  // availableBalance(0) + oldAmount(500) >= updateAmount(360)
 
         UpdateOrderRequestDto dto = UpdateOrderRequestDto.builder()
-                .updatePrice(120L)
-                .updateQuantity(8L)  // newRemaining = 8 - 5 = 3, updateAmount = 120 * 3 = 360
+                .accountPassword("1234")
+                .updatePrice(150L)
+                .updateQuantity(8L)  // newRemaining = 8 - 5 = 3, updateAmount = 150 * 3 = 450
                 .build();
 
         // when
         UpdateMatchOrderRequestDto result = orderService.validateAndUpdateOrder(orderId, dto);
 
         // then: total 기준(120*8=960)이 아닌 remaining 기준(120*3=360)으로 호출되어야 한다
-        verify(account).relockBalance(500L, 360L);
-        assertThat(result.getUpdatePrice()).isEqualTo(120L);
+        verify(account).relockBalance(500L, 450L);
+        assertThat(result.getUpdatePrice()).isEqualTo(150L);
         assertThat(result.getUpdateQuantity()).isEqualTo(3L); // remaining 기준
         assertThat(result.getOriginalPrice()).isEqualTo(100L);
         assertThat(result.getOriginalQuantity()).isEqualTo(10L);
@@ -377,6 +408,7 @@ class OrderServiceImplTest {
         // given
         Long orderId = 1L;
         Order order = mock(Order.class);
+        Account account = mock(Account.class);
         Member member = mock(Member.class);
         Token token = mock(Token.class);
         MemberTokenHolding holding = mock(MemberTokenHolding.class);
@@ -391,12 +423,14 @@ class OrderServiceImplTest {
         when(order.getToken()).thenReturn(token);
         when(token.getTokenId()).thenReturn(TOKEN_ID);
         when(orderRepository.findByMemberIdAndOrderId(MEMBER_ID, orderId)).thenReturn(Optional.of(order));
+        when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
         when(memberTokenHoldingRepository.findWithLockByMemberAndToken(member, token))
                 .thenReturn(Optional.of(holding));
         when(holding.getCurrentQuantity()).thenReturn(0L);  // currentQuantity(0) + oldQuantity(5) >= newRemaining(3)
 
         UpdateOrderRequestDto dto = UpdateOrderRequestDto.builder()
-                .updatePrice(120L)
+                .accountPassword("1234")
+                .updatePrice(150L)
                 .updateQuantity(8L)  // newRemaining = 8 - 5 = 3
                 .build();
 
@@ -421,7 +455,8 @@ class OrderServiceImplTest {
 
         // when & then
         BusinessException ex = assertThrows(BusinessException.class,
-                () -> orderService.validateAndCancelOrder(orderId));
+                () -> orderService.validateAndCancelOrder(orderId,
+                        server.main.order.dto.CancelOrderRequestDto.builder().accountPassword("1234").build()));
         assertThat(ex.getErrorCode()).isEqualTo(ORDER_CANNOT_CANCEL);
     }
 
@@ -501,8 +536,8 @@ class OrderServiceImplTest {
         orderService.processMatchResult(orderId, TOKEN_ID, matchResult);
 
         // then — orderPrice == tradePrice(12000)이라 차액 없음, lockedAmount == tradeAmount
-        verify(account).settleBuyTrade(60_000L, 60_000L); // tradeAmount=60000, lockedAmount=12000*5=60000
-        verify(counterAccount).settleSellTrade(60_000L);
+        verify(account).settleBuyTrade(60_000L, 60_000L, 0L); // tradeAmount=60000, lockedAmount=12000*5=60000
+        verify(counterAccount).settleSellTrade(60_000L, 0L);
         verify(buyerHolding).settleBuyTrade(5L, 12000L);
         verify(sellerHolding).settleSellTrade(5L);
         verify(tradeRepository).save(any());
@@ -582,8 +617,8 @@ class OrderServiceImplTest {
         // then
         // tradeAmount = 10000 * 5 = 50000, lockedAmount = 12000 * 5 = 60000
         // lockedBalance -= 60000, availableBalance += (60000 - 50000) = 10000 환급
-        verify(account).settleBuyTrade(50_000L, 60_000L);
-        verify(counterAccount).settleSellTrade(50_000L);
+        verify(account).settleBuyTrade(50_000L, 60_000L, 0L);
+        verify(counterAccount).settleSellTrade(50_000L, 0L);
     }
 
     @Test
@@ -830,8 +865,8 @@ class OrderServiceImplTest {
 
         // then — SELL incoming이므로 buyer=counter, seller=incoming
         // tradeAmount = 60000, lockedAmount = counterOrder.orderPrice(12000) * 5 = 60000
-        verify(counterAccount).settleBuyTrade(60_000L, 60_000L);
-        verify(sellerAccount).settleSellTrade(60_000L);
+        verify(counterAccount).settleBuyTrade(60_000L, 60_000L, 0L);
+        verify(sellerAccount).settleSellTrade(60_000L, 0L);
         verify(buyerHolding).settleBuyTrade(5L, 12000L);
         verify(sellerHolding).settleSellTrade(5L);
         verify(tradeRepository).save(any());

--- a/server/main/src/test/java/server/main/token/service/TokenServiceImplTest.java
+++ b/server/main/src/test/java/server/main/token/service/TokenServiceImplTest.java
@@ -299,10 +299,10 @@ class TokenServiceImplTest {
     @Test
     void getTokenAssetsWith10Paging_BASIC_DAY_정상조회() {
         Asset asset = Asset.builder().assetId(1L).assetName("서울 빌딩").build();
-        Token token = Token.builder().tokenId(1L).currentPrice(12000.0).asset(asset).build();
+        Token token = Token.builder().tokenId(1L).currentPrice(12000L).asset(asset).build();
 
-        CandleDay todayCandle = CandleDay.builder().openPrice(10000.0).closePrice(11000.0).token(token).build();
-        CandleDay sparkCandle = CandleDay.builder().closePrice(11500.0).token(token).build();
+        CandleDay todayCandle = CandleDay.builder().openPrice(10000L).closePrice(11000L).token(token).build();
+        CandleDay sparkCandle = CandleDay.builder().closePrice(11500L).token(token).build();
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
         when(candleDayRepository.findTodayByTokenIds(anyList(), any(), any())).thenReturn(List.of(todayCandle));
@@ -355,7 +355,7 @@ class TokenServiceImplTest {
     @Test
     void getTokenAssetsWith10Paging_거래없는토큰_집계기본값0() {
         Asset asset = Asset.builder().assetId(1L).assetName("무거래 토큰").build();
-        Token token = Token.builder().tokenId(1L).currentPrice(5000.0).asset(asset).build();
+        Token token = Token.builder().tokenId(1L).currentPrice(5000L).asset(asset).build();
 
         when(tokenRepository.findAllBySelectType(0, SelectType.TOTAL_TRADE_VALUE)).thenReturn(List.of(token));
         when(candleDayRepository.findTodayByTokenIds(anyList(), any(), any())).thenReturn(List.of());
@@ -371,7 +371,7 @@ class TokenServiceImplTest {
     @Test
     void getTokenAssetsWith10Paging_basePrice없으면_등락률0() {
         Asset asset = Asset.builder().assetId(1L).assetName("빌딩A").build();
-        Token token = Token.builder().tokenId(1L).currentPrice(8000.0).asset(asset).build();
+        Token token = Token.builder().tokenId(1L).currentPrice(8000L).asset(asset).build();
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
         when(candleDayRepository.findTodayByTokenIds(anyList(), any(), any())).thenReturn(List.of());  // 시가 없음
@@ -386,9 +386,9 @@ class TokenServiceImplTest {
     @Test
     void getTokenAssetsWith10Paging_MONTH_candleMonth사용() {
         Asset asset = Asset.builder().assetId(1L).assetName("월간 토큰").build();
-        Token token = Token.builder().tokenId(1L).currentPrice(20000.0).asset(asset).build();
+        Token token = Token.builder().tokenId(1L).currentPrice(20000L).asset(asset).build();
 
-        CandleMonth monthCandle = CandleMonth.builder().openPrice(18000.0).closePrice(19000.0).token(token).build();
+        CandleMonth monthCandle = CandleMonth.builder().openPrice(18000L).closePrice(19000L).token(token).build();
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
         when(candleMonthRepository.findThisMonthByTokenIds(anyList(), any(), any())).thenReturn(List.of(monthCandle));
@@ -406,9 +406,9 @@ class TokenServiceImplTest {
     @Test
     void getTokenAssetsWith10Paging_YEAR_candleYear사용() {
         Asset asset = Asset.builder().assetId(1L).assetName("연간 토큰").build();
-        Token token = Token.builder().tokenId(1L).currentPrice(30000.0).asset(asset).build();
+        Token token = Token.builder().tokenId(1L).currentPrice(30000L).asset(asset).build();
 
-        CandleYear yearCandle = CandleYear.builder().openPrice(25000.0).closePrice(28000.0).token(token).build();
+        CandleYear yearCandle = CandleYear.builder().openPrice(25000L).closePrice(28000L).token(token).build();
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
         when(candleYearRepository.findThisYearByTokenIds(anyList(), any(), any())).thenReturn(List.of(yearCandle));
@@ -426,12 +426,12 @@ class TokenServiceImplTest {
     void getTokenAssetsWith10Paging_스파크라인_복수토큰_tokenId별그룹핑() {
         Asset asset1 = Asset.builder().assetId(1L).assetName("A토큰").build();
         Asset asset2 = Asset.builder().assetId(2L).assetName("B토큰").build();
-        Token token1 = Token.builder().tokenId(1L).currentPrice(1000.0).asset(asset1).build();
-        Token token2 = Token.builder().tokenId(2L).currentPrice(2000.0).asset(asset2).build();
+        Token token1 = Token.builder().tokenId(1L).currentPrice(1000L).asset(asset1).build();
+        Token token2 = Token.builder().tokenId(2L).currentPrice(2000L).asset(asset2).build();
 
-        CandleDay spark1a = CandleDay.builder().closePrice(900.0).token(token1).build();
-        CandleDay spark1b = CandleDay.builder().closePrice(950.0).token(token1).build();
-        CandleDay spark2a = CandleDay.builder().closePrice(1800.0).token(token2).build();
+        CandleDay spark1a = CandleDay.builder().closePrice(900L).token(token1).build();
+        CandleDay spark1b = CandleDay.builder().closePrice(950L).token(token1).build();
+        CandleDay spark2a = CandleDay.builder().closePrice(1800L).token(token2).build();
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token1, token2));
         when(candleDayRepository.findTodayByTokenIds(anyList(), any(), any())).thenReturn(List.of());


### PR DESCRIPTION
## Summary
- add account password verification for buy, sell, update, and cancel actions
- add PIN keypad modal and final order confirmation modal in trading UI
- add account password verify API and cancel request password validation
- fix 401 handling so invalid account password does not log out the user

## Verification
- npm run build
- .\\gradlew.bat compileJava compileTestJava