### PR TITLE
Add trade integrity guards and failed order retry handling

### DIFF
--- a/server/main/src/main/java/server/main/blockchain/controller/BlockchainTestController.java
+++ b/server/main/src/main/java/server/main/blockchain/controller/BlockchainTestController.java
@@ -22,7 +22,7 @@ import java.time.LocalDateTime;
 @RestController
 @RequestMapping("test/blockchain")
 @RequiredArgsConstructor
-@Profile("!prod")
+@Profile("local")
 public class BlockchainTestController {
 
     private final TokenIssueService tokenIssueService;

--- a/server/main/src/main/java/server/main/blockchain/entity/BlockchainTx.java
+++ b/server/main/src/main/java/server/main/blockchain/entity/BlockchainTx.java
@@ -68,4 +68,21 @@ public class BlockchainTx {
     @Column(name = "tx_type", nullable = false)
     private BlockchainTxType txType;
 
+    @PrePersist
+    @PreUpdate
+    private void validateTradeAssociation() {
+        if (txType == null) {
+            throw new IllegalStateException("BlockchainTx txType must not be null");
+        }
+
+        if (txType == BlockchainTxType.TRADE) {
+            if (trade == null) {
+                throw new IllegalStateException("TRADE blockchain tx must reference a trade");
+            }
+            if (queueId == null) {
+                throw new IllegalStateException("TRADE blockchain tx must reference an outbox queue");
+            }
+        }
+    }
+
 }

--- a/server/main/src/main/java/server/main/myAccount/controller/MyAccountController.java
+++ b/server/main/src/main/java/server/main/myAccount/controller/MyAccountController.java
@@ -1,4 +1,4 @@
-package server.main.myaccount.controller;
+package server.main.myAccount.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/server/main/src/main/java/server/main/order/entity/Order.java
+++ b/server/main/src/main/java/server/main/order/entity/Order.java
@@ -92,6 +92,7 @@ public class Order extends BaseEntity {
 
     public void removeOrder() {
         this.orderStatus = OrderStatus.CANCELLED;
+        this.retryCount = 0;
         this.failedMatchResultJson = null;
     }
 
@@ -105,6 +106,7 @@ public class Order extends BaseEntity {
         this.filledQuantity = filledQuantity;
         this.remainingQuantity = remainingQuantity;
         this.orderStatus = status;
+        this.retryCount = 0;
         this.failedMatchResultJson = null;
     }
 

--- a/server/main/src/main/java/server/main/order/entity/Order.java
+++ b/server/main/src/main/java/server/main/order/entity/Order.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -59,6 +60,10 @@ public class Order extends BaseEntity {
     @Builder.Default
     private Integer retryCount = 0;
 
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String failedMatchResultJson;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "token_id")
     private Token token;
@@ -87,17 +92,20 @@ public class Order extends BaseEntity {
 
     public void removeOrder() {
         this.orderStatus = OrderStatus.CANCELLED;
+        this.failedMatchResultJson = null;
     }
 
-    public void markFailed() {
+    public void markFailed(String failedMatchResultJson) {
         this.orderStatus = OrderStatus.FAILED;
         this.retryCount = 0;
+        this.failedMatchResultJson = failedMatchResultJson;
     }
 
     public void applyMatchResult(Long filledQuantity, Long remainingQuantity, OrderStatus status) {
         this.filledQuantity = filledQuantity;
         this.remainingQuantity = remainingQuantity;
         this.orderStatus = status;
+        this.failedMatchResultJson = null;
     }
 
     public void increaseRetryCount() {

--- a/server/main/src/main/java/server/main/order/entity/Order.java
+++ b/server/main/src/main/java/server/main/order/entity/Order.java
@@ -16,6 +16,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.ColumnDefault;
 import server.main.global.util.BaseEntity;
 import server.main.member.entity.Member;
 import server.main.token.entity.Token;
@@ -34,25 +35,29 @@ public class Order extends BaseEntity {
     private Long orderId;
 
     @Column(nullable = true)
-    private Long orderSequence;         // 주문 순서 (match 서버가 부여, 주문 생성 시 null)
+    private Long orderSequence;
 
-    private Long orderPrice;            // 지정가 주문 가격 (호가)
+    private Long orderPrice;
 
-    private Long orderQuantity;         // 처음 요청한 매도 / 매수 수량
+    private Long orderQuantity;
 
     @Column(nullable = false)
     @Builder.Default
-    private Long filledQuantity = 0L;   // 체결 수량
+    private Long filledQuantity = 0L;
 
     @Column(nullable = false)
-    private Long remainingQuantity;     // 미체결 수량
+    private Long remainingQuantity;
 
     @Enumerated(EnumType.STRING)
-    private OrderType orderType;        // 매도, 매수 여부
+    private OrderType orderType;
 
     @Enumerated(EnumType.STRING)
-    private OrderStatus orderStatus;    // 호가 상태
+    private OrderStatus orderStatus;
 
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    @Builder.Default
+    private Integer retryCount = 0;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "token_id")
@@ -62,7 +67,6 @@ public class Order extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    // 주문 수정 전용 메서드 — 수정 후 match 재호출 전이므로 PENDING으로 전환
     public void updateOrder(Long updatePrice, Long updateQuantity) {
         this.orderPrice = updatePrice;
         this.orderQuantity = updateQuantity;
@@ -70,7 +74,6 @@ public class Order extends BaseEntity {
         this.orderStatus = OrderStatus.PENDING;
     }
 
-    // 보상 트랜잭션용 — match 실패 시 원래 가격/수량으로 복원하고 상태도 원복
     public void restoreOrder(Long originalPrice, Long originalQuantity) {
         this.orderPrice = originalPrice;
         this.orderQuantity = originalQuantity;
@@ -78,23 +81,33 @@ public class Order extends BaseEntity {
         this.orderStatus = this.filledQuantity > 0 ? OrderStatus.PARTIAL : OrderStatus.OPEN;
     }
 
-    // 취소 진행 중 표시 — match 서버 호출 전 PENDING으로 전환
     public void markCancelPending() {
         this.orderStatus = OrderStatus.PENDING;
     }
 
     public void removeOrder() {
-        // updatedAd은 자동으로 값이 채워진다
-        this.orderStatus = OrderStatus.CANCELLED; // 주문 취소
+        this.orderStatus = OrderStatus.CANCELLED;
     }
-    
+
+    public void markFailed() {
+        this.orderStatus = OrderStatus.FAILED;
+        this.retryCount = 0;
+    }
+
     public void applyMatchResult(Long filledQuantity, Long remainingQuantity, OrderStatus status) {
         this.filledQuantity = filledQuantity;
         this.remainingQuantity = remainingQuantity;
         this.orderStatus = status;
     }
 
-    // match 서버가 부여한 시간 우선순위 번호 저장
+    public void increaseRetryCount() {
+        this.retryCount++;
+    }
+
+    public void resetRetryCount() {
+        this.retryCount = 0;
+    }
+
     public void updateSequence(Long sequence) {
         this.orderSequence = sequence;
     }

--- a/server/main/src/main/java/server/main/order/entity/OrderStatus.java
+++ b/server/main/src/main/java/server/main/order/entity/OrderStatus.java
@@ -2,7 +2,7 @@ package server.main.order.entity;
 
 public enum OrderStatus {
     OPEN,       // 접수
-    PENDING,    // 대기 -> 매치쪽에서 필요한지 ?
+    PENDING,    // 대기 -> match 쪽 결과 반영 필요
     PARTIAL,    // 부분 체결
     FILLED,     // 전체 체결
     CANCELLED,  // 취소

--- a/server/main/src/main/java/server/main/order/repository/OrderRepository.java
+++ b/server/main/src/main/java/server/main/order/repository/OrderRepository.java
@@ -26,7 +26,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findOpenAndPartialByTokenId(@Param("tokenId") Long tokenId);
 
     @Query("SELECT o FROM Order o WHERE o.orderStatus = 'FAILED' AND o.remainingQuantity > 0 AND o.retryCount < 3 ORDER BY o.updatedAt ASC")
-    List<Order> findFailedOrdersForRetry();
+    List<Order> findFailedOrdersForRetry(Pageable pageable);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT o FROM Order o WHERE o.orderId = :orderId")

--- a/server/main/src/main/java/server/main/order/repository/OrderRepository.java
+++ b/server/main/src/main/java/server/main/order/repository/OrderRepository.java
@@ -25,6 +25,9 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query("SELECT o FROM Order o WHERE o.token.tokenId = :tokenId AND o.orderStatus IN ('OPEN', 'PARTIAL') AND o.remainingQuantity > 0")
     List<Order> findOpenAndPartialByTokenId(@Param("tokenId") Long tokenId);
 
+    @Query("SELECT o FROM Order o WHERE o.orderStatus = 'FAILED' AND o.remainingQuantity > 0 ORDER BY o.updatedAt ASC")
+    List<Order> findFailedOrdersForRetry();
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT o FROM Order o WHERE o.orderId = :orderId")
     Optional<Order> findWithLockById(@Param("orderId") Long orderId);

--- a/server/main/src/main/java/server/main/order/repository/OrderRepository.java
+++ b/server/main/src/main/java/server/main/order/repository/OrderRepository.java
@@ -25,7 +25,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query("SELECT o FROM Order o WHERE o.token.tokenId = :tokenId AND o.orderStatus IN ('OPEN', 'PARTIAL') AND o.remainingQuantity > 0")
     List<Order> findOpenAndPartialByTokenId(@Param("tokenId") Long tokenId);
 
-    @Query("SELECT o FROM Order o WHERE o.orderStatus = 'FAILED' AND o.remainingQuantity > 0 ORDER BY o.updatedAt ASC")
+    @Query("SELECT o FROM Order o WHERE o.orderStatus = 'FAILED' AND o.remainingQuantity > 0 AND o.retryCount < 3 ORDER BY o.updatedAt ASC")
     List<Order> findFailedOrdersForRetry();
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/server/main/src/main/java/server/main/order/service/FailedOrderRetryScheduler.java
+++ b/server/main/src/main/java/server/main/order/service/FailedOrderRetryScheduler.java
@@ -11,7 +11,10 @@ public class FailedOrderRetryScheduler {
 
     private final OrderService orderService;
 
-    @Scheduled(fixedDelay = 60000)
+    @Scheduled(
+            fixedDelayString = "${order.retry.failed.fixed-delay-ms:60000}",
+            initialDelayString = "${order.retry.failed.initial-delay-ms:60000}"
+    )
     public void retryFailedOrders() {
         orderService.retryFailedOrders();
     }

--- a/server/main/src/main/java/server/main/order/service/FailedOrderRetryScheduler.java
+++ b/server/main/src/main/java/server/main/order/service/FailedOrderRetryScheduler.java
@@ -1,0 +1,18 @@
+package server.main.order.service;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FailedOrderRetryScheduler {
+
+    private final OrderService orderService;
+
+    @Scheduled(fixedDelay = 60000)
+    public void retryFailedOrders() {
+        orderService.retryFailedOrders();
+    }
+}

--- a/server/main/src/main/java/server/main/order/service/OrderFacade.java
+++ b/server/main/src/main/java/server/main/order/service/OrderFacade.java
@@ -42,7 +42,7 @@ public class OrderFacade {
             orderService.processMatchResult(matchDto.getOrderId(), tokenId, matchResult);
         } catch (RuntimeException e) {
             log.error("Match phase 2 failed. orderId={}", matchDto.getOrderId(), e);
-            orderService.markOrderFailed(matchDto.getOrderId());
+            orderService.markOrderFailed(matchDto.getOrderId(), matchResult);
             throw e;
         }
     }
@@ -63,7 +63,7 @@ public class OrderFacade {
             orderService.processMatchResult(orderId, matchDto.getTokenId(), matchResult);
         } catch (RuntimeException e) {
             log.error("Update order phase 2 failed. orderId={}", orderId, e);
-            orderService.markOrderFailed(orderId);
+            orderService.markOrderFailed(orderId, matchResult);
             throw e;
         }
     }

--- a/server/main/src/main/java/server/main/order/service/OrderFacade.java
+++ b/server/main/src/main/java/server/main/order/service/OrderFacade.java
@@ -38,7 +38,13 @@ public class OrderFacade {
             throw new BusinessException(MATCH_SERVICE_UNAVAILABLE);
         }
 
-        orderService.processMatchResult(matchDto.getOrderId(), tokenId, matchResult);
+        try {
+            orderService.processMatchResult(matchDto.getOrderId(), tokenId, matchResult);
+        } catch (RuntimeException e) {
+            log.error("match Phase 2 ?ㅽ뙣. orderId={}", matchDto.getOrderId(), e);
+            orderService.markOrderFailed(matchDto.getOrderId());
+            throw e;
+        }
     }
 
     public void updateOrder(Long orderId, UpdateOrderRequestDto dto) {
@@ -53,7 +59,13 @@ public class OrderFacade {
             throw new BusinessException(MATCH_SERVICE_UNAVAILABLE);
         }
 
-        orderService.processMatchResult(orderId, matchDto.getTokenId(), matchResult);
+        try {
+            orderService.processMatchResult(orderId, matchDto.getTokenId(), matchResult);
+        } catch (RuntimeException e) {
+            log.error("updateOrder Phase 2 ?ㅽ뙣. orderId={}", orderId, e);
+            orderService.markOrderFailed(orderId);
+            throw e;
+        }
     }
 
     public void cancelOrder(Long orderId, CancelOrderRequestDto dto) {

--- a/server/main/src/main/java/server/main/order/service/OrderFacade.java
+++ b/server/main/src/main/java/server/main/order/service/OrderFacade.java
@@ -1,6 +1,6 @@
 package server.main.order.service;
 
-import static server.main.global.error.ErrorCode.*;
+import static server.main.global.error.ErrorCode.MATCH_SERVICE_UNAVAILABLE;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
@@ -33,7 +33,7 @@ public class OrderFacade {
         try {
             matchResult = matchClient.sendOrder(matchDto);
         } catch (RestClientException e) {
-            log.error("match 서버 호출 실패. orderId={}", matchDto.getOrderId(), e);
+            log.error("Match service call failed. orderId={}", matchDto.getOrderId(), e);
             orderService.compensateFailedOrder(matchDto.getOrderId());
             throw new BusinessException(MATCH_SERVICE_UNAVAILABLE);
         }
@@ -41,7 +41,7 @@ public class OrderFacade {
         try {
             orderService.processMatchResult(matchDto.getOrderId(), tokenId, matchResult);
         } catch (RuntimeException e) {
-            log.error("match Phase 2 ?ㅽ뙣. orderId={}", matchDto.getOrderId(), e);
+            log.error("Match phase 2 failed. orderId={}", matchDto.getOrderId(), e);
             orderService.markOrderFailed(matchDto.getOrderId());
             throw e;
         }
@@ -54,7 +54,7 @@ public class OrderFacade {
         try {
             matchResult = matchClient.updateOrder(matchDto);
         } catch (RestClientException e) {
-            log.error("match 서버 호출 실패. orderId={}", orderId, e);
+            log.error("Match service call failed. orderId={}", orderId, e);
             orderService.compensateFailedUpdate(orderId, matchDto.getOriginalPrice(), matchDto.getOriginalQuantity());
             throw new BusinessException(MATCH_SERVICE_UNAVAILABLE);
         }
@@ -62,7 +62,7 @@ public class OrderFacade {
         try {
             orderService.processMatchResult(orderId, matchDto.getTokenId(), matchResult);
         } catch (RuntimeException e) {
-            log.error("updateOrder Phase 2 ?ㅽ뙣. orderId={}", orderId, e);
+            log.error("Update order phase 2 failed. orderId={}", orderId, e);
             orderService.markOrderFailed(orderId);
             throw e;
         }
@@ -74,11 +74,11 @@ public class OrderFacade {
         try {
             matchClient.cancelOrder(ctx.getOrderId(), ctx.getTokenId());
         } catch (HttpClientErrorException.NotFound e) {
-            log.warn("match 서버에 취소 대상 주문이 없어 취소 완료로 정리합니다. orderId={}", orderId, e);
+            log.warn("Cancel target was not found on match service. Marking as cancelled. orderId={}", orderId, e);
             orderService.completeCancelOrder(orderId);
             return;
         } catch (RestClientException e) {
-            log.error("match 서버 호출 실패. orderId={}", orderId, e);
+            log.error("Match service call failed. orderId={}", orderId, e);
             orderService.compensateFailedCancel(ctx);
             throw new BusinessException(MATCH_SERVICE_UNAVAILABLE);
         }

--- a/server/main/src/main/java/server/main/order/service/OrderService.java
+++ b/server/main/src/main/java/server/main/order/service/OrderService.java
@@ -12,7 +12,7 @@ public interface OrderService {
     // Phase 2: 체결 결과 반영 + 이벤트 발행 → 커밋
     void processMatchResult(Long orderId, Long tokenId, MatchResultDto matchResult);
 
-    void markOrderFailed(Long orderId);
+    void markOrderFailed(Long orderId, MatchResultDto matchResult);
 
     void retryFailedOrder(Long orderId);
 

--- a/server/main/src/main/java/server/main/order/service/OrderService.java
+++ b/server/main/src/main/java/server/main/order/service/OrderService.java
@@ -12,6 +12,12 @@ public interface OrderService {
     // Phase 2: 체결 결과 반영 + 이벤트 발행 → 커밋
     void processMatchResult(Long orderId, Long tokenId, MatchResultDto matchResult);
 
+    void markOrderFailed(Long orderId);
+
+    void retryFailedOrder(Long orderId);
+
+    void retryFailedOrders();
+
     // match 실패 시 보상 트랜잭션: 잔고 복구 + 주문 취소
     void compensateFailedOrder(Long orderId);
 

--- a/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
+++ b/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
@@ -94,6 +95,7 @@ import server.main.trade.repository.TradeRepository;
 public class OrderServiceImpl implements OrderService {
 
     private static final int MAX_FAILED_RETRY = 3;
+    private static final int FAILED_RETRY_BATCH_SIZE = 100;
 
     private final OrderMapper orderMapper;
     private final OrderLogService orderLogService;
@@ -708,7 +710,7 @@ public class OrderServiceImpl implements OrderService {
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     @Override
     public void retryFailedOrders() {
-        List<Order> failedOrders = orderRepository.findFailedOrdersForRetry();
+        List<Order> failedOrders = orderRepository.findFailedOrdersForRetry(PageRequest.of(0, FAILED_RETRY_BATCH_SIZE));
         for (Order failedOrder : failedOrders) {
             try {
                 retryFailedOrder(failedOrder.getOrderId());
@@ -721,8 +723,18 @@ public class OrderServiceImpl implements OrderService {
     @Transactional
     @Override
     public void compensateFailedOrder(Long orderId) {
-        Order order = orderRepository.findById(orderId)
+        Order order = orderRepository.findWithLockById(orderId)
                 .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+
+        if (order.getOrderStatus() != OrderStatus.FAILED || order.getRemainingQuantity() <= 0) {
+            log.warn(
+                    "Skipping automatic compensation because order state changed before cancellation. orderId={}, orderStatus={}, remainingQuantity={}",
+                    orderId,
+                    order.getOrderStatus(),
+                    order.getRemainingQuantity()
+            );
+            return;
+        }
 
         if (OrderType.BUY.equals(order.getOrderType())) {
             Account account = accountRepository.findWithLockByMember(order.getMember())

--- a/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
+++ b/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
@@ -19,7 +19,11 @@ import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -110,8 +114,9 @@ public class OrderServiceImpl implements OrderService {
     private final BankingRepository bankingRepository;
     private final PlatformBankingRepository platformBankingRepository;
     private final MatchClient matchClient;
+    private final PlatformTransactionManager transactionManager;
 
-    // createOrder Phase 1: 검증 + 잔고 차감 + 주문 저장
+    // createOrder Phase 1: 寃利?+ ?붽퀬 李④컧 + 二쇰Ц ???
     private void validateMatchResult(Order findOrder, MatchResultDto matchResult) {
         if (matchResult == null
                 || matchResult.getFilledQuantity() == null
@@ -124,8 +129,9 @@ public class OrderServiceImpl implements OrderService {
         long remainingQuantity = matchResult.getRemainingQuantity();
         long currentFilled = findOrder.getFilledQuantity();
         long orderQuantity = findOrder.getOrderQuantity();
+        long availableQuantity = orderQuantity - currentFilled;
 
-        if (filledQuantity < 0 || remainingQuantity < 0) {
+        if (filledQuantity < 0 || remainingQuantity < 0 || availableQuantity < 0) {
             throw new BusinessException(INVALID_INPUT_VALUE);
         }
 
@@ -133,9 +139,11 @@ public class OrderServiceImpl implements OrderService {
             throw new BusinessException(INVALID_INPUT_VALUE);
         }
 
-        long executionTotal = matchResult.getExecutions().stream()
-                .mapToLong(TradeExecutionDto::getTradeQuantity)
-                .sum();
+        long executionTotal = 0L;
+        for (TradeExecutionDto execution : matchResult.getExecutions()) {
+            validateExecution(execution, availableQuantity);
+            executionTotal += execution.getTradeQuantity();
+        }
 
         if (executionTotal != filledQuantity) {
             throw new BusinessException(INVALID_INPUT_VALUE);
@@ -146,7 +154,7 @@ public class OrderServiceImpl implements OrderService {
         }
     }
 
-    private void validateExecution(Order findOrder, TradeExecutionDto execution) {
+    private void validateExecution(TradeExecutionDto execution, long availableQuantity) {
         if (execution == null
                 || execution.getCounterMemberId() == null
                 || execution.getCounterOrderId() == null
@@ -159,9 +167,19 @@ public class OrderServiceImpl implements OrderService {
             throw new BusinessException(INVALID_INPUT_VALUE);
         }
 
-        if (execution.getTradeQuantity() > findOrder.getRemainingQuantity()) {
+        if (execution.getTradeQuantity() > availableQuantity) {
             throw new BusinessException(INVALID_INPUT_VALUE);
         }
+    }
+
+    private void executeInTransaction(Runnable action) {
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> action.run());
+    }
+
+    private void executeInRequiresNewTransaction(Runnable action) {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        template.executeWithoutResult(status -> action.run());
     }
 
     @Transactional
@@ -175,10 +193,10 @@ public class OrderServiceImpl implements OrderService {
         Token findToken = tokenRepository.findById(tokenId)
                 .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
 
-        // 호가 단위 검증
+        // ?멸? ?⑥쐞 寃利?
         TickSizePolicy.validate(dto.getOrderPrice());
 
-        // 매수일 경우
+        // 留ㅼ닔??寃쎌슦
         if (OrderType.BUY.equals(dto.getOrderType())) {
 
             Account findMemberAccount = accountRepository.findWithLockByMember(findMember)
@@ -197,7 +215,7 @@ public class OrderServiceImpl implements OrderService {
                 findMemberAccount.lockBalance(totalLockAmount);
         }
 
-        // 매도일 경우
+        // 留ㅻ룄??寃쎌슦
         if (OrderType.SELL.equals(dto.getOrderType())) {
             Account findMemberAccount = accountRepository.findWithLockByMember(findMember)
                     .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
@@ -213,7 +231,7 @@ public class OrderServiceImpl implements OrderService {
             findMemberHolding.lockQuantity(dto.getOrderQuantity());
         }
 
-        // 주문 생성
+        // 二쇰Ц ?앹꽦
         Order createOrder = Order.builder()
                 .orderPrice(dto.getOrderPrice())
                 .orderQuantity(dto.getOrderQuantity())
@@ -228,8 +246,8 @@ public class OrderServiceImpl implements OrderService {
 
         orderRepository.save(createOrder);
 
-        // 로그 저장
-        String detail = String.format("토큰=%s 가격=%d 수량=%d",
+        // 濡쒓렇 ???
+        String detail = String.format("?좏겙=%s 媛寃?%d ?섎웾=%d",
                 findToken.getTokenName(), dto.getOrderPrice(), dto.getOrderQuantity());
         orderLogService.save(findMember.getMemberName(), String.valueOf(dto.getOrderType()), detail, true);
 
@@ -243,7 +261,7 @@ public class OrderServiceImpl implements OrderService {
                 .build();
     }
 
-    // createOrder / updateOrder Phase 2: 체결 결과 반영
+    // createOrder / updateOrder Phase 2: 泥닿껐 寃곌낵 諛섏쁺
     @Retryable(retryFor = CannotAcquireLockException.class, maxAttempts = 3, backoff = @Backoff(delay = 100))
     @Transactional
     @Override
@@ -256,7 +274,7 @@ public class OrderServiceImpl implements OrderService {
         Long memberId = findMember.getMemberId();
         validateMatchResult(findOrder, matchResult);
 
-        // ORDERS 테이블 업데이트 — match 서버는 누적 체결을 모르므로 main 에서 상태 재계산
+        // ORDERS ?뚯씠釉??낅뜲?댄듃 ??match ?쒕쾭???꾩쟻 泥닿껐??紐⑤Ⅴ誘濡?main ?먯꽌 ?곹깭 ?ш퀎??
         long newTotalFilled = findOrder.getFilledQuantity() + matchResult.getFilledQuantity();
 
         OrderStatus finalStatus;
@@ -273,7 +291,7 @@ public class OrderServiceImpl implements OrderService {
 
         boolean isBuy = OrderType.BUY.equals(findOrder.getOrderType());
 
-        // findMember Account/Holding — 체결 건이 있을 때만 조회
+        // findMember Account/Holding ??泥닿껐 嫄댁씠 ?덉쓣 ?뚮쭔 議고쉶
         Account findMemberAccount = null;
         MemberTokenHolding findMemberHolding = null;
 
@@ -295,7 +313,6 @@ public class OrderServiceImpl implements OrderService {
         }
 
         for (TradeExecutionDto execution : matchResult.getExecutions()) {
-            validateExecution(findOrder, execution);
             Member counterMember = memberRepository.findById(execution.getCounterMemberId())
                     .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
             Order counterOrder = orderRepository.findWithLockById(execution.getCounterOrderId())
@@ -308,7 +325,7 @@ public class OrderServiceImpl implements OrderService {
                     .tradePrice(execution.getTradePrice())
                     .tradeQuantity(execution.getTradeQuantity())
                     .totalTradePrice(tradeAmount)
-                    .feeAmount(feeAmount) // 매수자 또는 매도자 각 한쪽 기준 수수료 (플랫폼 총 수수료 = feeAmount × 2)
+                    .feeAmount(feeAmount) // 留ㅼ닔???먮뒗 留ㅻ룄??媛??쒖そ 湲곗? ?섏닔猷?(?뚮옯??珥??섏닔猷?= feeAmount 횞 2)
                     .settlementStatus(SettlementStatus.ON_CHAIN_PENDING)
                     .executedAt(LocalDateTime.now())
                     .token(findToken)
@@ -320,12 +337,12 @@ public class OrderServiceImpl implements OrderService {
 
             tradeRepository.save(trade);
 
-            // 체결가로 토큰 현재가 갱신
+            // 泥닿껐媛濡??좏겙 ?꾩옱媛 媛깆떊
             findToken.updateCurrentPrice(execution.getTradePrice());
 
-            // admin 대시보드 이벤트 (거래 체결 시 대시보드 실시간 업데이트)
+            // admin ??쒕낫???대깽??(嫄곕옒 泥닿껐 ????쒕낫???ㅼ떆媛??낅뜲?댄듃)
             eventPublisher.publishEvent(new AdminDashboardEvent());
-            // admin 대시보드 실시간 업데이트 용 (체결 거래내역 실시간 업데이트) > 범근
+            // admin ??쒕낫???ㅼ떆媛??낅뜲?댄듃 ??(泥닿껐 嫄곕옒?댁뿭 ?ㅼ떆媛??낅뜲?댄듃) > 踰붽렐
             eventPublisher.publishEvent(new TradeExecutedEvent(
                     DashBoardTradeListDTO.builder()
                             .tradeId(trade.getTradeId())
@@ -362,10 +379,10 @@ public class OrderServiceImpl implements OrderService {
             buyerAccount.settleBuyTrade(tradeAmount, totalLockedAmount, feeAmount);
             sellerAccount.settleSellTrade(tradeAmount, feeAmount);
 
-            // platform_accounts 수수료 적립 (매수+매도 수수료 합산)
+            // platform_accounts ?섏닔猷??곷┰ (留ㅼ닔+留ㅻ룄 ?섏닔猷??⑹궛)
             platformAccount.earnFee(feeAmount * 2);
 
-            // platform_banking 이력 저장
+            // platform_banking ?대젰 ???
             platformBankingRepository.save(PlatformBanking.builder()
                     .tokenId(findToken.getTokenId())
                     .tradeId(trade.getTradeId())
@@ -374,7 +391,7 @@ public class OrderServiceImpl implements OrderService {
                     .platformBankingDirection(PlatformDirection.DEPOSIT)
                     .build());
 
-            // 매수자 거래 이력
+            // 留ㅼ닔??嫄곕옒 ?대젰
             bankingRepository.save(MemberBank.builder()
                     .account(buyerAccount)
                     .txType(TxType.TRADE_SETTLEMENT_BUY)
@@ -383,7 +400,7 @@ public class OrderServiceImpl implements OrderService {
                     .balanceSnapshot(buyerAccount.getAvailableBalance())
                     .build());
 
-            // 매도자 거래 이력
+            // 留ㅻ룄??嫄곕옒 ?대젰
             bankingRepository.save(MemberBank.builder()
                     .account(sellerAccount)
                     .txType(TxType.TRADE_SETTLEMENT_SELL)
@@ -392,7 +409,7 @@ public class OrderServiceImpl implements OrderService {
                     .balanceSnapshot(sellerAccount.getAvailableBalance())
                     .build());
 
-            // 매수자 Holding 반영
+            // 留ㅼ닔??Holding 諛섏쁺
             MemberTokenHolding buyerHolding;
             if (isBuy) {
                 buyerHolding = findMemberHolding;
@@ -423,7 +440,7 @@ public class OrderServiceImpl implements OrderService {
                 buyerHolding.settleBuyTrade(execution.getTradeQuantity(), execution.getTradePrice());
             }
 
-            // 매도자 Holding 반영
+            // 留ㅻ룄??Holding 諛섏쁺
             MemberTokenHolding sellerHolding;
             if (isBuy) {
                 sellerHolding = counterHoldingCache.get(execution.getCounterMemberId());
@@ -441,7 +458,7 @@ public class OrderServiceImpl implements OrderService {
             sellerHolding.settleSellTrade(execution.getTradeQuantity());
             blockchainOutboxService.saveTradeOutbox(trade, findToken);
 
-            // 상대방 주문 상태 DB 업데이트
+            // ?곷?諛?二쇰Ц ?곹깭 DB ?낅뜲?댄듃
             long newFilledQty = counterOrder.getFilledQuantity() + execution.getTradeQuantity();
             long newRemainingQty = counterOrder.getRemainingQuantity() - execution.getTradeQuantity();
             if (newFilledQty < 0
@@ -453,7 +470,7 @@ public class OrderServiceImpl implements OrderService {
             OrderStatus counterStatus = newRemainingQty == 0 ? OrderStatus.FILLED : OrderStatus.PARTIAL;
             counterOrder.applyMatchResult(newFilledQty, newRemainingQty, counterStatus);
 
-            // trades_duplicated 저장
+            // trades_duplicated ???
             tradeDuplicatedRepository.save(TradeDuplicated.builder()
                     .tradeId(trade.getTradeId())
                     .sellerId(trade.getSeller().getMemberId())
@@ -470,7 +487,7 @@ public class OrderServiceImpl implements OrderService {
                     .createdAt(LocalDateTime.now())
                     .build());
 
-            // orders_duplicated — 상대방 주문 FILLED 시
+            // orders_duplicated ???곷?諛?二쇰Ц FILLED ??
             if (counterStatus == OrderStatus.FILLED) {
                 orderDuplicatedRepository.save(OrderDuplicated.builder()
                         .orderId(counterOrder.getOrderId())
@@ -490,7 +507,7 @@ public class OrderServiceImpl implements OrderService {
             }
         }
 
-        // orders_duplicated — 내 주문 FILLED 시 (재계산된 상태 기준)
+        // orders_duplicated ????二쇰Ц FILLED ??(?ш퀎?곕맂 ?곹깭 湲곗?)
         if (findOrder.getOrderStatus() == OrderStatus.FILLED) {
             orderDuplicatedRepository.save(OrderDuplicated.builder()
                     .orderId(findOrder.getOrderId())
@@ -509,29 +526,29 @@ public class OrderServiceImpl implements OrderService {
                     .build());
         }
 
-        // 주문 체결 시 발생할 알람 리스트
+        // 二쇰Ц 泥닿껐 ??諛쒖깮???뚮엺 由ъ뒪??
         List<AlarmEvent.AlarmRecord> alarmRecords = new ArrayList<>();
         String tokenName = findToken.getTokenName();
 
-        // 알람 생성 : 주문이 체결되었을 때 알람 생성, FILLED, PARTIAL 구분 // 나와 상대 모두에게 알람 전달
+        // ?뚮엺 ?앹꽦 : 二쇰Ц??泥닿껐?섏뿀?????뚮엺 ?앹꽦, FILLED, PARTIAL 援щ텇 // ?섏? ?곷? 紐⑤몢?먭쾶 ?뚮엺 ?꾨떖
         if ((finalStatus == OrderStatus.FILLED || finalStatus == OrderStatus.PARTIAL)
                 && !matchResult.getExecutions().isEmpty()) {
-            String orderTypeLabel = isBuy ? "매수" : "매도";
+            String orderTypeLabel = isBuy ? "留ㅼ닔" : "留ㅻ룄";
             AlarmType myAlarmType = finalStatus == OrderStatus.FILLED ? AlarmType.ORDER_FILLED
-                    : AlarmType.ORDER_PARTIAL; // 부분 체결, 전체 체결 판단
+                    : AlarmType.ORDER_PARTIAL; // 遺遺?泥닿껐, ?꾩껜 泥닿껐 ?먮떒
             long totalFilled = matchResult.getExecutions().stream().mapToLong(TradeExecutionDto::getTradeQuantity)
                     .sum();
             long tradePrice = matchResult.getExecutions().get(0).getTradePrice();
-            String myMsg = String.format("[ %s ] %s 주문 %,d원 × %d주 %s",
+            String myMsg = String.format("[ %s ] %s 二쇰Ц %,d??횞 %d二?%s",
                     tokenName, orderTypeLabel, tradePrice, totalFilled,
-                    finalStatus == OrderStatus.FILLED ? "체결 완료" : "부분 체결");
+                    finalStatus == OrderStatus.FILLED ? "泥닿껐 ?꾨즺" : "遺遺?泥닿껐");
 
             alarmRecords.add(new AlarmEvent.AlarmRecord(memberId, myAlarmType, tokenId, myMsg));
         }
 
-        // 상대방 알람 생성
+        // ?곷?諛??뚮엺 ?앹꽦
         Set<Long> notifiedCounters = new HashSet<>();
-        for (TradeExecutionDto execution : matchResult.getExecutions()) { // 매치에서 체결된 내역을 꺼낸다
+        for (TradeExecutionDto execution : matchResult.getExecutions()) { // 留ㅼ튂?먯꽌 泥닿껐???댁뿭??爰쇰궦??
             Long counterMemberId = execution.getCounterMemberId();
             if (notifiedCounters.contains(counterMemberId))
                 continue;
@@ -544,23 +561,23 @@ public class OrderServiceImpl implements OrderService {
             if (counterStatus != OrderStatus.FILLED && counterStatus != OrderStatus.PARTIAL)
                 continue;
 
-            String counterTypeLabel = isBuy ? "매도" : "매수"; // 내가 매수자면 상대방은 매도자, 내가 매도자면 상대방은 매수자.
+            String counterTypeLabel = isBuy ? "留ㅻ룄" : "留ㅼ닔"; // ?닿? 留ㅼ닔?먮㈃ ?곷?諛⑹? 留ㅻ룄?? ?닿? 留ㅻ룄?먮㈃ ?곷?諛⑹? 留ㅼ닔??
             AlarmType counterAlarmType = counterStatus == OrderStatus.FILLED ? AlarmType.ORDER_FILLED
                     : AlarmType.ORDER_PARTIAL;
-            String counterMsg = String.format("[ %s ] %s 주문 %,d원 × %d주 %s",
+            String counterMsg = String.format("[ %s ] %s 二쇰Ц %,d??횞 %d二?%s",
                     tokenName, counterTypeLabel, execution.getTradePrice(), execution.getTradeQuantity(),
-                    counterStatus == OrderStatus.FILLED ? "체결 완료" : "부분 체결");
+                    counterStatus == OrderStatus.FILLED ? "泥닿껐 ?꾨즺" : "遺遺?泥닿껐");
 
             alarmRecords.add(new AlarmEvent.AlarmRecord(counterMemberId, counterAlarmType, tokenId, counterMsg));
             notifiedCounters.add(counterMemberId);
         }
 
-        // 이벤트 발생
+        // ?대깽??諛쒖깮
         if (!alarmRecords.isEmpty()) {
             eventPublisher.publishEvent(new AlarmEvent(alarmRecords));
         }
 
-        // WebSocket push 이벤트 발행 — 커밋 후 리스너가 실행
+        // WebSocket push ?대깽??諛쒗뻾 ??而ㅻ컠 ??由ъ뒪?덇? ?ㅽ뻾
         List<Long> counterMemberIds = matchResult.getExecutions().stream()
                 .map(TradeExecutionDto::getCounterMemberId)
                 .distinct()
@@ -568,7 +585,7 @@ public class OrderServiceImpl implements OrderService {
         eventPublisher.publishEvent(new OrderWebSocketEvent(tokenId, memberId, counterMemberIds));
     }
 
-    // match 실패 시 보상: 잔고 복구 + 주문 삭제
+    // match ?ㅽ뙣 ??蹂댁긽: ?붽퀬 蹂듦뎄 + 二쇰Ц ??젣
     @Transactional
     @Override
     public void markOrderFailed(Long orderId) {
@@ -577,18 +594,19 @@ public class OrderServiceImpl implements OrderService {
         order.markFailed();
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     @Override
     public void retryFailedOrder(Long orderId) {
-        Order order = orderRepository.findWithLockById(orderId)
+        Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
 
         if (order.getOrderStatus() != OrderStatus.FAILED || order.getRemainingQuantity() <= 0) {
             return;
         }
 
+        Long tokenId = order.getToken().getTokenId();
         MatchOrderRequestDto retryDto = MatchOrderRequestDto.builder()
-                .tokenId(order.getToken().getTokenId())
+                .tokenId(tokenId)
                 .memberId(order.getMember().getMemberId())
                 .orderId(order.getOrderId())
                 .orderPrice(order.getOrderPrice())
@@ -598,19 +616,36 @@ public class OrderServiceImpl implements OrderService {
 
         try {
             MatchResultDto matchResult = matchClient.sendOrder(retryDto);
-            processMatchResult(order.getOrderId(), order.getToken().getTokenId(), matchResult);
-            order.resetRetryCount();
+            executeInTransaction(() -> {
+                Order lockedOrder = orderRepository.findWithLockById(orderId)
+                        .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+                if (lockedOrder.getOrderStatus() != OrderStatus.FAILED || lockedOrder.getRemainingQuantity() <= 0) {
+                    return;
+                }
+
+                processMatchResult(lockedOrder.getOrderId(), tokenId, matchResult);
+                lockedOrder.resetRetryCount();
+            });
         } catch (RuntimeException e) {
-            order.increaseRetryCount();
-            if (order.getRetryCount() >= MAX_FAILED_RETRY) {
-                compensateFailedOrder(order.getOrderId());
-                log.warn("FAILED 주문 자동 재처리 한도 초과로 취소 처리. orderId={}, retryCount={}",
-                        order.getOrderId(), order.getRetryCount());
-            }
+            executeInRequiresNewTransaction(() -> {
+                Order lockedOrder = orderRepository.findWithLockById(orderId)
+                        .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+                if (lockedOrder.getOrderStatus() != OrderStatus.FAILED || lockedOrder.getRemainingQuantity() <= 0) {
+                    return;
+                }
+
+                lockedOrder.increaseRetryCount();
+                if (lockedOrder.getRetryCount() >= MAX_FAILED_RETRY) {
+                    compensateFailedOrder(lockedOrder.getOrderId());
+                    log.warn("Failed order retry limit exceeded. Cancelling order. orderId={}, retryCount={}",
+                            lockedOrder.getOrderId(), lockedOrder.getRetryCount());
+                }
+            });
             throw e;
         }
     }
 
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     @Override
     public void retryFailedOrders() {
         List<Order> failedOrders = orderRepository.findFailedOrdersForRetry();
@@ -618,7 +653,7 @@ public class OrderServiceImpl implements OrderService {
             try {
                 retryFailedOrder(failedOrder.getOrderId());
             } catch (RuntimeException e) {
-                log.error("FAILED 주문 자동 재처리 실패. orderId={}", failedOrder.getOrderId(), e);
+                log.error("Failed order retry failed. orderId={}", failedOrder.getOrderId(), e);
             }
         }
     }
@@ -647,7 +682,7 @@ public class OrderServiceImpl implements OrderService {
         order.removeOrder();
     }
 
-    // updateOrder Phase 1: 검증 + 잔고 재조정 + 주문 수정
+    // updateOrder Phase 1: 寃利?+ ?붽퀬 ?ъ“??+ 二쇰Ц ?섏젙
     @Transactional
     @Override
     public UpdateMatchOrderRequestDto validateAndUpdateOrder(Long orderId, UpdateOrderRequestDto dto) {
@@ -658,7 +693,7 @@ public class OrderServiceImpl implements OrderService {
         Order findOrder = orderRepository.findByMemberIdAndOrderId(memberId, orderId)
                 .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
 
-        // 호가 단위 검증
+        // ?멸? ?⑥쐞 寃利?
         TickSizePolicy.validate(dto.getUpdatePrice());
 
         OrderStatus status = findOrder.getOrderStatus();
@@ -708,7 +743,7 @@ public class OrderServiceImpl implements OrderService {
             }
         }
 
-        // 수정 전 값 저장 (보상용) — updateOrder 호출 전에 가져와야 함
+        // ?섏젙 ??媛????(蹂댁긽?? ??updateOrder ?몄텧 ?꾩뿉 媛?몄?????
         Long originalPrice = findOrder.getOrderPrice();
         Long originalQuantity = findOrder.getOrderQuantity();
 
@@ -724,7 +759,7 @@ public class OrderServiceImpl implements OrderService {
                 .build();
     }
 
-    // update match 실패 시 보상: 원래 가격/수량으로 복구
+    // update match ?ㅽ뙣 ??蹂댁긽: ?먮옒 媛寃??섎웾?쇰줈 蹂듦뎄
     @Transactional
     @Override
     public void compensateFailedUpdate(Long orderId, Long originalPrice, Long originalQuantity) {
@@ -755,7 +790,7 @@ public class OrderServiceImpl implements OrderService {
         order.restoreOrder(originalPrice, originalQuantity);
     }
 
-    // 미체결 주문 조회
+    // 誘몄껜寃?二쇰Ц 議고쉶
     @Override
     public List<PendingOrderResponseDto> getPendingOrders(Long tokenId) {
         CustomUserPrincipal principal = (CustomUserPrincipal) SecurityContextHolder.getContext().getAuthentication()
@@ -766,7 +801,7 @@ public class OrderServiceImpl implements OrderService {
         return orderMapper.toPendingDtoList(pendingOrders);
     }
 
-    // cancelOrder Phase 1: 검증 + 잔고 복구 + PENDING 전환
+    // cancelOrder Phase 1: 寃利?+ ?붽퀬 蹂듦뎄 + PENDING ?꾪솚
     @Transactional
     @Override
     public CancelOrderContext validateAndCancelOrder(Long orderId, CancelOrderRequestDto dto) {
@@ -817,7 +852,7 @@ public class OrderServiceImpl implements OrderService {
                 .build();
     }
 
-    // cancelOrder Phase 2: CANCELLED 최종 전환
+    // cancelOrder Phase 2: CANCELLED 理쒖쥌 ?꾪솚
     @Transactional
     @Override
     public void completeCancelOrder(Long orderId) {
@@ -826,7 +861,7 @@ public class OrderServiceImpl implements OrderService {
         findOrder.removeOrder();
     }
 
-    // cancel match 실패 시 보상: 잔고 재잠금 + 상태 복원
+    // cancel match ?ㅽ뙣 ??蹂댁긽: ?붽퀬 ?ъ옞湲?+ ?곹깭 蹂듭썝
     @Transactional
     @Override
     public void compensateFailedCancel(CancelOrderContext ctx) {
@@ -851,7 +886,7 @@ public class OrderServiceImpl implements OrderService {
         findOrder.restoreOrder(ctx.getOrderPrice(), findOrder.getOrderQuantity());
     }
 
-    // 주문 가능 금액/수량 조회
+    // 二쇰Ц 媛??湲덉븸/?섎웾 議고쉶
     @Override
     public OrderCapacityResponseDto getOrderCapacity(Long tokenId) {
         Long memberId = ((CustomUserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal())
@@ -878,3 +913,6 @@ public class OrderServiceImpl implements OrderService {
         }
     }
 }
+
+
+

--- a/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
+++ b/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
@@ -726,7 +726,9 @@ public class OrderServiceImpl implements OrderService {
         Order order = orderRepository.findWithLockById(orderId)
                 .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
 
-        if (order.getOrderStatus() != OrderStatus.FAILED || order.getRemainingQuantity() <= 0) {
+        boolean compensableStatus = order.getOrderStatus() == OrderStatus.PENDING
+                || order.getOrderStatus() == OrderStatus.FAILED;
+        if (!compensableStatus || order.getRemainingQuantity() <= 0) {
             log.warn(
                     "Skipping automatic compensation because order state changed before cancellation. orderId={}, orderStatus={}, remainingQuantity={}",
                     orderId,

--- a/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
+++ b/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
@@ -118,11 +118,18 @@ public class OrderServiceImpl implements OrderService {
     private final PlatformTransactionManager transactionManager;
 
     // Validate a match result before applying it to the main database.
-    private void validateMatchResult(Order findOrder, MatchResultDto matchResult) {
+    private void validateMatchResult(Order findOrder, Long tokenId, MatchResultDto matchResult) {
         if (matchResult == null
+                || matchResult.getOrderId() == null
+                || matchResult.getTokenId() == null
                 || matchResult.getFilledQuantity() == null
                 || matchResult.getRemainingQuantity() == null
                 || matchResult.getExecutions() == null) {
+            throw new BusinessException(INVALID_INPUT_VALUE);
+        }
+
+        if (!findOrder.getOrderId().equals(matchResult.getOrderId())
+                || !tokenId.equals(matchResult.getTokenId())) {
             throw new BusinessException(INVALID_INPUT_VALUE);
         }
 
@@ -201,7 +208,7 @@ public class OrderServiceImpl implements OrderService {
                 .build();
     }
 
-    private record RetryOrderSnapshot(Long tokenId, UpdateMatchOrderRequestDto retryDto) {
+    private record RetryOrderSnapshot(Long tokenId, MatchResultDto matchResult) {
     }
 
     @Transactional
@@ -290,7 +297,7 @@ public class OrderServiceImpl implements OrderService {
                 .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
         Member findMember = findOrder.getMember();
         Long memberId = findMember.getMemberId();
-        validateMatchResult(findOrder, matchResult);
+        validateMatchResult(findOrder, tokenId, matchResult);
 
         long newTotalFilled = findOrder.getFilledQuantity() + matchResult.getFilledQuantity();
 
@@ -585,10 +592,14 @@ public class OrderServiceImpl implements OrderService {
 
     @Transactional
     @Override
-    public void markOrderFailed(Long orderId) {
+    public void markOrderFailed(Long orderId, MatchResultDto matchResult) {
         Order order = orderRepository.findWithLockById(orderId)
                 .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
-        order.markFailed();
+        try {
+            order.markFailed(objectMapper.writeValueAsString(matchResult));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to serialize match result for retry.", e);
+        }
     }
 
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
@@ -602,14 +613,19 @@ public class OrderServiceImpl implements OrderService {
                 return null;
             }
 
-            Long tokenId = order.getToken().getTokenId();
-            UpdateMatchOrderRequestDto retryDto = UpdateMatchOrderRequestDto.builder()
-                    .orderId(order.getOrderId())
-                    .tokenId(tokenId)
-                    .updatePrice(order.getOrderPrice())
-                    .updateQuantity(order.getRemainingQuantity())
-                    .build();
-            return new RetryOrderSnapshot(tokenId, retryDto);
+            if (order.getFailedMatchResultJson() == null || order.getFailedMatchResultJson().isBlank()) {
+                throw new IllegalStateException("Missing stored match result for failed order retry.");
+            }
+
+            try {
+                MatchResultDto storedMatchResult = objectMapper.readValue(
+                        order.getFailedMatchResultJson(),
+                        MatchResultDto.class
+                );
+                return new RetryOrderSnapshot(order.getToken().getTokenId(), storedMatchResult);
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to deserialize stored match result.", e);
+            }
         });
 
         if (snapshot == null) {
@@ -617,7 +633,6 @@ public class OrderServiceImpl implements OrderService {
         }
 
         try {
-            MatchResultDto matchResult = matchClient.updateOrder(snapshot.retryDto());
             createLockRetryTemplate().execute(context -> {
                 executeInTransaction(() -> {
                     Order lockedOrder = orderRepository.findWithLockById(orderId)
@@ -627,7 +642,7 @@ public class OrderServiceImpl implements OrderService {
                         return;
                     }
 
-                    processMatchResult(lockedOrder.getOrderId(), snapshot.tokenId(), matchResult);
+                    processMatchResult(lockedOrder.getOrderId(), snapshot.tokenId(), snapshot.matchResult());
                     lockedOrder.resetRetryCount();
                 });
                 return null;
@@ -652,6 +667,8 @@ public class OrderServiceImpl implements OrderService {
                 matchClient.cancelOrder(orderId, snapshot.tokenId());
             } catch (org.springframework.web.client.HttpClientErrorException.NotFound notFound) {
                 log.warn("Retry cancel target was not found on match service. orderId={}", orderId, notFound);
+            } catch (org.springframework.web.client.RestClientException cancelException) {
+                log.error("Failed to cancel order on match service after retry limit. orderId={}", orderId, cancelException);
             }
 
             executeInRequiresNewTransaction(() -> {

--- a/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
+++ b/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
@@ -42,6 +42,7 @@ import server.main.alarm.service.AlarmService;
 import server.main.blockchain.service.BlockchainOutboxService;
 import server.main.global.error.BusinessException;
 import server.main.global.security.CustomUserPrincipal;
+import server.main.global.util.MatchClient;
 import server.main.global.util.TickSizePolicy;
 import server.main.log.orderLog.service.OrderLogService;
 import server.main.myAccount.entity.Account;
@@ -86,6 +87,8 @@ import server.main.trade.repository.TradeRepository;
 @Slf4j
 public class OrderServiceImpl implements OrderService {
 
+    private static final int MAX_FAILED_RETRY = 3;
+
     private final OrderMapper orderMapper;
     private final OrderLogService orderLogService;
     private final OrderRepository orderRepository;
@@ -106,8 +109,61 @@ public class OrderServiceImpl implements OrderService {
     private final PlatformAccountRepository platformAccountRepository;
     private final BankingRepository bankingRepository;
     private final PlatformBankingRepository platformBankingRepository;
+    private final MatchClient matchClient;
 
     // createOrder Phase 1: 검증 + 잔고 차감 + 주문 저장
+    private void validateMatchResult(Order findOrder, MatchResultDto matchResult) {
+        if (matchResult == null
+                || matchResult.getFilledQuantity() == null
+                || matchResult.getRemainingQuantity() == null
+                || matchResult.getExecutions() == null) {
+            throw new BusinessException(INVALID_INPUT_VALUE);
+        }
+
+        long filledQuantity = matchResult.getFilledQuantity();
+        long remainingQuantity = matchResult.getRemainingQuantity();
+        long currentFilled = findOrder.getFilledQuantity();
+        long orderQuantity = findOrder.getOrderQuantity();
+
+        if (filledQuantity < 0 || remainingQuantity < 0) {
+            throw new BusinessException(INVALID_INPUT_VALUE);
+        }
+
+        if (currentFilled + filledQuantity > orderQuantity || remainingQuantity > orderQuantity) {
+            throw new BusinessException(INVALID_INPUT_VALUE);
+        }
+
+        long executionTotal = matchResult.getExecutions().stream()
+                .mapToLong(TradeExecutionDto::getTradeQuantity)
+                .sum();
+
+        if (executionTotal != filledQuantity) {
+            throw new BusinessException(INVALID_INPUT_VALUE);
+        }
+
+        if (orderQuantity - (currentFilled + filledQuantity) != remainingQuantity) {
+            throw new BusinessException(INVALID_INPUT_VALUE);
+        }
+    }
+
+    private void validateExecution(Order findOrder, TradeExecutionDto execution) {
+        if (execution == null
+                || execution.getCounterMemberId() == null
+                || execution.getCounterOrderId() == null
+                || execution.getTradePrice() == null
+                || execution.getTradeQuantity() == null) {
+            throw new BusinessException(INVALID_INPUT_VALUE);
+        }
+
+        if (execution.getTradePrice() <= 0 || execution.getTradeQuantity() <= 0) {
+            throw new BusinessException(INVALID_INPUT_VALUE);
+        }
+
+        if (execution.getTradeQuantity() > findOrder.getRemainingQuantity()) {
+            throw new BusinessException(INVALID_INPUT_VALUE);
+        }
+    }
+
     @Transactional
     @Override
     public MatchOrderRequestDto validateAndSaveOrder(Long tokenId, OrderRequestDto dto) {
@@ -198,6 +254,7 @@ public class OrderServiceImpl implements OrderService {
                 .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
         Member findMember = findOrder.getMember();
         Long memberId = findMember.getMemberId();
+        validateMatchResult(findOrder, matchResult);
 
         // ORDERS 테이블 업데이트 — match 서버는 누적 체결을 모르므로 main 에서 상태 재계산
         long newTotalFilled = findOrder.getFilledQuantity() + matchResult.getFilledQuantity();
@@ -238,6 +295,7 @@ public class OrderServiceImpl implements OrderService {
         }
 
         for (TradeExecutionDto execution : matchResult.getExecutions()) {
+            validateExecution(findOrder, execution);
             Member counterMember = memberRepository.findById(execution.getCounterMemberId())
                     .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
             Order counterOrder = orderRepository.findWithLockById(execution.getCounterOrderId())
@@ -385,7 +443,13 @@ public class OrderServiceImpl implements OrderService {
 
             // 상대방 주문 상태 DB 업데이트
             long newFilledQty = counterOrder.getFilledQuantity() + execution.getTradeQuantity();
-            long newRemainingQty = Math.max(0L, counterOrder.getRemainingQuantity() - execution.getTradeQuantity());
+            long newRemainingQty = counterOrder.getRemainingQuantity() - execution.getTradeQuantity();
+            if (newFilledQty < 0
+                    || newFilledQty > counterOrder.getOrderQuantity()
+                    || newRemainingQty < 0
+                    || newRemainingQty > counterOrder.getOrderQuantity()) {
+                throw new BusinessException(INVALID_INPUT_VALUE);
+            }
             OrderStatus counterStatus = newRemainingQty == 0 ? OrderStatus.FILLED : OrderStatus.PARTIAL;
             counterOrder.applyMatchResult(newFilledQty, newRemainingQty, counterStatus);
 
@@ -505,6 +569,60 @@ public class OrderServiceImpl implements OrderService {
     }
 
     // match 실패 시 보상: 잔고 복구 + 주문 삭제
+    @Transactional
+    @Override
+    public void markOrderFailed(Long orderId) {
+        Order order = orderRepository.findWithLockById(orderId)
+                .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+        order.markFailed();
+    }
+
+    @Transactional
+    @Override
+    public void retryFailedOrder(Long orderId) {
+        Order order = orderRepository.findWithLockById(orderId)
+                .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+
+        if (order.getOrderStatus() != OrderStatus.FAILED || order.getRemainingQuantity() <= 0) {
+            return;
+        }
+
+        MatchOrderRequestDto retryDto = MatchOrderRequestDto.builder()
+                .tokenId(order.getToken().getTokenId())
+                .memberId(order.getMember().getMemberId())
+                .orderId(order.getOrderId())
+                .orderPrice(order.getOrderPrice())
+                .orderQuantity(order.getRemainingQuantity())
+                .orderType(order.getOrderType())
+                .build();
+
+        try {
+            MatchResultDto matchResult = matchClient.sendOrder(retryDto);
+            processMatchResult(order.getOrderId(), order.getToken().getTokenId(), matchResult);
+            order.resetRetryCount();
+        } catch (RuntimeException e) {
+            order.increaseRetryCount();
+            if (order.getRetryCount() >= MAX_FAILED_RETRY) {
+                compensateFailedOrder(order.getOrderId());
+                log.warn("FAILED 주문 자동 재처리 한도 초과로 취소 처리. orderId={}, retryCount={}",
+                        order.getOrderId(), order.getRetryCount());
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public void retryFailedOrders() {
+        List<Order> failedOrders = orderRepository.findFailedOrdersForRetry();
+        for (Order failedOrder : failedOrders) {
+            try {
+                retryFailedOrder(failedOrder.getOrderId());
+            } catch (RuntimeException e) {
+                log.error("FAILED 주문 자동 재처리 실패. orderId={}", failedOrder.getOrderId(), e);
+            }
+        }
+    }
+
     @Transactional
     @Override
     public void compensateFailedOrder(Long orderId) {

--- a/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
+++ b/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
@@ -663,12 +663,38 @@ public class OrderServiceImpl implements OrderService {
                 throw e;
             }
 
+            Long snapshotRemainingQuantity = snapshot.matchResult().getRemainingQuantity();
+            Long orderRemainingQuantity = executeInRequiresNewTransactionWithResult(() -> {
+                Order lockedOrder = orderRepository.findWithLockById(orderId)
+                        .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+                if (lockedOrder.getOrderStatus() != OrderStatus.FAILED || lockedOrder.getRemainingQuantity() <= 0) {
+                    return null;
+                }
+                return lockedOrder.getRemainingQuantity();
+            });
+
             try {
                 matchClient.cancelOrder(orderId, snapshot.tokenId());
             } catch (org.springframework.web.client.HttpClientErrorException.NotFound notFound) {
                 log.warn("Retry cancel target was not found on match service. orderId={}", orderId, notFound);
             } catch (org.springframework.web.client.RestClientException cancelException) {
                 log.error("Failed to cancel order on match service after retry limit. orderId={}", orderId, cancelException);
+            }
+
+            if (orderRemainingQuantity == null) {
+                return;
+            }
+
+            if (!snapshotRemainingQuantity.equals(orderRemainingQuantity)) {
+                log.error(
+                        "Failed order retry limit exceeded with mismatched remaining quantity. "
+                                + "Skipping automatic compensation to avoid over-refund. Manual intervention required. "
+                                + "orderId={}, orderRemainingQuantity={}, failedSnapshotRemainingQuantity={}",
+                        orderId,
+                        orderRemainingQuantity,
+                        snapshotRemainingQuantity
+                );
+                return;
             }
 
             executeInRequiresNewTransaction(() -> {

--- a/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
+++ b/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -685,7 +686,7 @@ public class OrderServiceImpl implements OrderService {
                 return;
             }
 
-            if (!snapshotRemainingQuantity.equals(orderRemainingQuantity)) {
+            if (!Objects.equals(snapshotRemainingQuantity, orderRemainingQuantity)) {
                 log.error(
                         "Failed order retry limit exceeded with mismatched remaining quantity. "
                                 + "Skipping automatic compensation to avoid over-refund. Manual intervention required. "
@@ -963,6 +964,3 @@ public class OrderServiceImpl implements OrderService {
         }
     }
 }
-
-
-

--- a/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
+++ b/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -116,7 +117,7 @@ public class OrderServiceImpl implements OrderService {
     private final MatchClient matchClient;
     private final PlatformTransactionManager transactionManager;
 
-    // createOrder Phase 1: 寃利?+ ?붽퀬 李④컧 + 二쇰Ц ???
+    // Validate a match result before applying it to the main database.
     private void validateMatchResult(Order findOrder, MatchResultDto matchResult) {
         if (matchResult == null
                 || matchResult.getFilledQuantity() == null
@@ -182,6 +183,27 @@ public class OrderServiceImpl implements OrderService {
         template.executeWithoutResult(status -> action.run());
     }
 
+    private <T> T executeInTransactionWithResult(java.util.function.Supplier<T> action) {
+        return new TransactionTemplate(transactionManager).execute(status -> action.get());
+    }
+
+    private <T> T executeInRequiresNewTransactionWithResult(java.util.function.Supplier<T> action) {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return template.execute(status -> action.get());
+    }
+
+    private RetryTemplate createLockRetryTemplate() {
+        return RetryTemplate.builder()
+                .maxAttempts(3)
+                .fixedBackoff(100)
+                .retryOn(CannotAcquireLockException.class)
+                .build();
+    }
+
+    private record RetryOrderSnapshot(Long tokenId, UpdateMatchOrderRequestDto retryDto) {
+    }
+
     @Transactional
     @Override
     public MatchOrderRequestDto validateAndSaveOrder(Long tokenId, OrderRequestDto dto) {
@@ -193,10 +215,8 @@ public class OrderServiceImpl implements OrderService {
         Token findToken = tokenRepository.findById(tokenId)
                 .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
 
-        // ?멸? ?⑥쐞 寃利?
         TickSizePolicy.validate(dto.getOrderPrice());
 
-        // 留ㅼ닔??寃쎌슦
         if (OrderType.BUY.equals(dto.getOrderType())) {
 
             Account findMemberAccount = accountRepository.findWithLockByMember(findMember)
@@ -215,7 +235,6 @@ public class OrderServiceImpl implements OrderService {
                 findMemberAccount.lockBalance(totalLockAmount);
         }
 
-        // 留ㅻ룄??寃쎌슦
         if (OrderType.SELL.equals(dto.getOrderType())) {
             Account findMemberAccount = accountRepository.findWithLockByMember(findMember)
                     .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
@@ -231,7 +250,6 @@ public class OrderServiceImpl implements OrderService {
             findMemberHolding.lockQuantity(dto.getOrderQuantity());
         }
 
-        // 二쇰Ц ?앹꽦
         Order createOrder = Order.builder()
                 .orderPrice(dto.getOrderPrice())
                 .orderQuantity(dto.getOrderQuantity())
@@ -246,8 +264,8 @@ public class OrderServiceImpl implements OrderService {
 
         orderRepository.save(createOrder);
 
-        // 濡쒓렇 ???
-        String detail = String.format("?좏겙=%s 媛寃?%d ?섎웾=%d",
+        // Save an order log entry.
+        String detail = String.format("token=%s price=%d quantity=%d",
                 findToken.getTokenName(), dto.getOrderPrice(), dto.getOrderQuantity());
         orderLogService.save(findMember.getMemberName(), String.valueOf(dto.getOrderType()), detail, true);
 
@@ -261,7 +279,7 @@ public class OrderServiceImpl implements OrderService {
                 .build();
     }
 
-    // createOrder / updateOrder Phase 2: 泥닿껐 寃곌낵 諛섏쁺
+    // createOrder / updateOrder Phase 2: apply the match result
     @Retryable(retryFor = CannotAcquireLockException.class, maxAttempts = 3, backoff = @Backoff(delay = 100))
     @Transactional
     @Override
@@ -274,7 +292,6 @@ public class OrderServiceImpl implements OrderService {
         Long memberId = findMember.getMemberId();
         validateMatchResult(findOrder, matchResult);
 
-        // ORDERS ?뚯씠釉??낅뜲?댄듃 ??match ?쒕쾭???꾩쟻 泥닿껐??紐⑤Ⅴ誘濡?main ?먯꽌 ?곹깭 ?ш퀎??
         long newTotalFilled = findOrder.getFilledQuantity() + matchResult.getFilledQuantity();
 
         OrderStatus finalStatus;
@@ -291,7 +308,6 @@ public class OrderServiceImpl implements OrderService {
 
         boolean isBuy = OrderType.BUY.equals(findOrder.getOrderType());
 
-        // findMember Account/Holding ??泥닿껐 嫄댁씠 ?덉쓣 ?뚮쭔 議고쉶
         Account findMemberAccount = null;
         MemberTokenHolding findMemberHolding = null;
 
@@ -325,7 +341,7 @@ public class OrderServiceImpl implements OrderService {
                     .tradePrice(execution.getTradePrice())
                     .tradeQuantity(execution.getTradeQuantity())
                     .totalTradePrice(tradeAmount)
-                    .feeAmount(feeAmount) // 留ㅼ닔???먮뒗 留ㅻ룄??媛??쒖そ 湲곗? ?섏닔猷?(?뚮옯??珥??섏닔猷?= feeAmount 횞 2)
+                    .feeAmount(feeAmount) // One-side fee. Platform revenue is feeAmount * 2.
                     .settlementStatus(SettlementStatus.ON_CHAIN_PENDING)
                     .executedAt(LocalDateTime.now())
                     .token(findToken)
@@ -337,12 +353,9 @@ public class OrderServiceImpl implements OrderService {
 
             tradeRepository.save(trade);
 
-            // 泥닿껐媛濡??좏겙 ?꾩옱媛 媛깆떊
             findToken.updateCurrentPrice(execution.getTradePrice());
 
-            // admin ??쒕낫???대깽??(嫄곕옒 泥닿껐 ????쒕낫???ㅼ떆媛??낅뜲?댄듃)
             eventPublisher.publishEvent(new AdminDashboardEvent());
-            // admin ??쒕낫???ㅼ떆媛??낅뜲?댄듃 ??(泥닿껐 嫄곕옒?댁뿭 ?ㅼ떆媛??낅뜲?댄듃) > 踰붽렐
             eventPublisher.publishEvent(new TradeExecutedEvent(
                     DashBoardTradeListDTO.builder()
                             .tradeId(trade.getTradeId())
@@ -379,10 +392,8 @@ public class OrderServiceImpl implements OrderService {
             buyerAccount.settleBuyTrade(tradeAmount, totalLockedAmount, feeAmount);
             sellerAccount.settleSellTrade(tradeAmount, feeAmount);
 
-            // platform_accounts ?섏닔猷??곷┰ (留ㅼ닔+留ㅻ룄 ?섏닔猷??⑹궛)
             platformAccount.earnFee(feeAmount * 2);
 
-            // platform_banking ?대젰 ???
             platformBankingRepository.save(PlatformBanking.builder()
                     .tokenId(findToken.getTokenId())
                     .tradeId(trade.getTradeId())
@@ -391,7 +402,6 @@ public class OrderServiceImpl implements OrderService {
                     .platformBankingDirection(PlatformDirection.DEPOSIT)
                     .build());
 
-            // 留ㅼ닔??嫄곕옒 ?대젰
             bankingRepository.save(MemberBank.builder()
                     .account(buyerAccount)
                     .txType(TxType.TRADE_SETTLEMENT_BUY)
@@ -400,7 +410,6 @@ public class OrderServiceImpl implements OrderService {
                     .balanceSnapshot(buyerAccount.getAvailableBalance())
                     .build());
 
-            // 留ㅻ룄??嫄곕옒 ?대젰
             bankingRepository.save(MemberBank.builder()
                     .account(sellerAccount)
                     .txType(TxType.TRADE_SETTLEMENT_SELL)
@@ -409,7 +418,6 @@ public class OrderServiceImpl implements OrderService {
                     .balanceSnapshot(sellerAccount.getAvailableBalance())
                     .build());
 
-            // 留ㅼ닔??Holding 諛섏쁺
             MemberTokenHolding buyerHolding;
             if (isBuy) {
                 buyerHolding = findMemberHolding;
@@ -440,7 +448,6 @@ public class OrderServiceImpl implements OrderService {
                 buyerHolding.settleBuyTrade(execution.getTradeQuantity(), execution.getTradePrice());
             }
 
-            // 留ㅻ룄??Holding 諛섏쁺
             MemberTokenHolding sellerHolding;
             if (isBuy) {
                 sellerHolding = counterHoldingCache.get(execution.getCounterMemberId());
@@ -458,7 +465,6 @@ public class OrderServiceImpl implements OrderService {
             sellerHolding.settleSellTrade(execution.getTradeQuantity());
             blockchainOutboxService.saveTradeOutbox(trade, findToken);
 
-            // ?곷?諛?二쇰Ц ?곹깭 DB ?낅뜲?댄듃
             long newFilledQty = counterOrder.getFilledQuantity() + execution.getTradeQuantity();
             long newRemainingQty = counterOrder.getRemainingQuantity() - execution.getTradeQuantity();
             if (newFilledQty < 0
@@ -470,7 +476,6 @@ public class OrderServiceImpl implements OrderService {
             OrderStatus counterStatus = newRemainingQty == 0 ? OrderStatus.FILLED : OrderStatus.PARTIAL;
             counterOrder.applyMatchResult(newFilledQty, newRemainingQty, counterStatus);
 
-            // trades_duplicated ???
             tradeDuplicatedRepository.save(TradeDuplicated.builder()
                     .tradeId(trade.getTradeId())
                     .sellerId(trade.getSeller().getMemberId())
@@ -487,7 +492,6 @@ public class OrderServiceImpl implements OrderService {
                     .createdAt(LocalDateTime.now())
                     .build());
 
-            // orders_duplicated ???곷?諛?二쇰Ц FILLED ??
             if (counterStatus == OrderStatus.FILLED) {
                 orderDuplicatedRepository.save(OrderDuplicated.builder()
                         .orderId(counterOrder.getOrderId())
@@ -507,7 +511,6 @@ public class OrderServiceImpl implements OrderService {
             }
         }
 
-        // orders_duplicated ????二쇰Ц FILLED ??(?ш퀎?곕맂 ?곹깭 湲곗?)
         if (findOrder.getOrderStatus() == OrderStatus.FILLED) {
             orderDuplicatedRepository.save(OrderDuplicated.builder()
                     .orderId(findOrder.getOrderId())
@@ -526,29 +529,26 @@ public class OrderServiceImpl implements OrderService {
                     .build());
         }
 
-        // 二쇰Ц 泥닿껐 ??諛쒖깮???뚮엺 由ъ뒪??
         List<AlarmEvent.AlarmRecord> alarmRecords = new ArrayList<>();
         String tokenName = findToken.getTokenName();
 
-        // ?뚮엺 ?앹꽦 : 二쇰Ц??泥닿껐?섏뿀?????뚮엺 ?앹꽦, FILLED, PARTIAL 援щ텇 // ?섏? ?곷? 紐⑤몢?먭쾶 ?뚮엺 ?꾨떖
         if ((finalStatus == OrderStatus.FILLED || finalStatus == OrderStatus.PARTIAL)
                 && !matchResult.getExecutions().isEmpty()) {
-            String orderTypeLabel = isBuy ? "留ㅼ닔" : "留ㅻ룄";
+            String orderTypeLabel = isBuy ? "BUY" : "SELL";
             AlarmType myAlarmType = finalStatus == OrderStatus.FILLED ? AlarmType.ORDER_FILLED
-                    : AlarmType.ORDER_PARTIAL; // 遺遺?泥닿껐, ?꾩껜 泥닿껐 ?먮떒
+                    : AlarmType.ORDER_PARTIAL;
             long totalFilled = matchResult.getExecutions().stream().mapToLong(TradeExecutionDto::getTradeQuantity)
                     .sum();
             long tradePrice = matchResult.getExecutions().get(0).getTradePrice();
-            String myMsg = String.format("[ %s ] %s 二쇰Ц %,d??횞 %d二?%s",
+            String myMsg = String.format("[ %s ] %s order %,d KRW x %d units %s",
                     tokenName, orderTypeLabel, tradePrice, totalFilled,
-                    finalStatus == OrderStatus.FILLED ? "泥닿껐 ?꾨즺" : "遺遺?泥닿껐");
+                    finalStatus == OrderStatus.FILLED ? "filled" : "partially filled");
 
             alarmRecords.add(new AlarmEvent.AlarmRecord(memberId, myAlarmType, tokenId, myMsg));
         }
 
-        // ?곷?諛??뚮엺 ?앹꽦
         Set<Long> notifiedCounters = new HashSet<>();
-        for (TradeExecutionDto execution : matchResult.getExecutions()) { // 留ㅼ튂?먯꽌 泥닿껐???댁뿭??爰쇰궦??
+        for (TradeExecutionDto execution : matchResult.getExecutions()) {
             Long counterMemberId = execution.getCounterMemberId();
             if (notifiedCounters.contains(counterMemberId))
                 continue;
@@ -561,23 +561,21 @@ public class OrderServiceImpl implements OrderService {
             if (counterStatus != OrderStatus.FILLED && counterStatus != OrderStatus.PARTIAL)
                 continue;
 
-            String counterTypeLabel = isBuy ? "留ㅻ룄" : "留ㅼ닔"; // ?닿? 留ㅼ닔?먮㈃ ?곷?諛⑹? 留ㅻ룄?? ?닿? 留ㅻ룄?먮㈃ ?곷?諛⑹? 留ㅼ닔??
+            String counterTypeLabel = isBuy ? "SELL" : "BUY";
             AlarmType counterAlarmType = counterStatus == OrderStatus.FILLED ? AlarmType.ORDER_FILLED
                     : AlarmType.ORDER_PARTIAL;
-            String counterMsg = String.format("[ %s ] %s 二쇰Ц %,d??횞 %d二?%s",
+            String counterMsg = String.format("[ %s ] %s order %,d KRW x %d units %s",
                     tokenName, counterTypeLabel, execution.getTradePrice(), execution.getTradeQuantity(),
-                    counterStatus == OrderStatus.FILLED ? "泥닿껐 ?꾨즺" : "遺遺?泥닿껐");
+                    counterStatus == OrderStatus.FILLED ? "filled" : "partially filled");
 
             alarmRecords.add(new AlarmEvent.AlarmRecord(counterMemberId, counterAlarmType, tokenId, counterMsg));
             notifiedCounters.add(counterMemberId);
         }
 
-        // ?대깽??諛쒖깮
         if (!alarmRecords.isEmpty()) {
             eventPublisher.publishEvent(new AlarmEvent(alarmRecords));
         }
 
-        // WebSocket push ?대깽??諛쒗뻾 ??而ㅻ컠 ??由ъ뒪?덇? ?ㅽ뻾
         List<Long> counterMemberIds = matchResult.getExecutions().stream()
                 .map(TradeExecutionDto::getCounterMemberId)
                 .distinct()
@@ -585,7 +583,6 @@ public class OrderServiceImpl implements OrderService {
         eventPublisher.publishEvent(new OrderWebSocketEvent(tokenId, memberId, counterMemberIds));
     }
 
-    // match ?ㅽ뙣 ??蹂댁긽: ?붽퀬 蹂듦뎄 + 二쇰Ц ??젣
     @Transactional
     @Override
     public void markOrderFailed(Long orderId) {
@@ -597,51 +594,70 @@ public class OrderServiceImpl implements OrderService {
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     @Override
     public void retryFailedOrder(Long orderId) {
-        Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+        RetryOrderSnapshot snapshot = executeInTransactionWithResult(() -> {
+            Order order = orderRepository.findById(orderId)
+                    .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
 
-        if (order.getOrderStatus() != OrderStatus.FAILED || order.getRemainingQuantity() <= 0) {
+            if (order.getOrderStatus() != OrderStatus.FAILED || order.getRemainingQuantity() <= 0) {
+                return null;
+            }
+
+            Long tokenId = order.getToken().getTokenId();
+            UpdateMatchOrderRequestDto retryDto = UpdateMatchOrderRequestDto.builder()
+                    .orderId(order.getOrderId())
+                    .tokenId(tokenId)
+                    .updatePrice(order.getOrderPrice())
+                    .updateQuantity(order.getRemainingQuantity())
+                    .build();
+            return new RetryOrderSnapshot(tokenId, retryDto);
+        });
+
+        if (snapshot == null) {
             return;
         }
 
-        Long tokenId = order.getToken().getTokenId();
-        MatchOrderRequestDto retryDto = MatchOrderRequestDto.builder()
-                .tokenId(tokenId)
-                .memberId(order.getMember().getMemberId())
-                .orderId(order.getOrderId())
-                .orderPrice(order.getOrderPrice())
-                .orderQuantity(order.getRemainingQuantity())
-                .orderType(order.getOrderType())
-                .build();
-
         try {
-            MatchResultDto matchResult = matchClient.sendOrder(retryDto);
-            executeInTransaction(() -> {
-                Order lockedOrder = orderRepository.findWithLockById(orderId)
-                        .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
-                if (lockedOrder.getOrderStatus() != OrderStatus.FAILED || lockedOrder.getRemainingQuantity() <= 0) {
-                    return;
-                }
+            MatchResultDto matchResult = matchClient.updateOrder(snapshot.retryDto());
+            createLockRetryTemplate().execute(context -> {
+                executeInTransaction(() -> {
+                    Order lockedOrder = orderRepository.findWithLockById(orderId)
+                            .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
+                    if (lockedOrder.getOrderStatus() != OrderStatus.FAILED
+                            || lockedOrder.getRemainingQuantity() <= 0) {
+                        return;
+                    }
 
-                processMatchResult(lockedOrder.getOrderId(), tokenId, matchResult);
-                lockedOrder.resetRetryCount();
+                    processMatchResult(lockedOrder.getOrderId(), snapshot.tokenId(), matchResult);
+                    lockedOrder.resetRetryCount();
+                });
+                return null;
             });
         } catch (RuntimeException e) {
-            executeInRequiresNewTransaction(() -> {
+            boolean shouldCancel = executeInRequiresNewTransactionWithResult(() -> {
                 Order lockedOrder = orderRepository.findWithLockById(orderId)
                         .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
                 if (lockedOrder.getOrderStatus() != OrderStatus.FAILED || lockedOrder.getRemainingQuantity() <= 0) {
-                    return;
+                    return false;
                 }
 
                 lockedOrder.increaseRetryCount();
-                if (lockedOrder.getRetryCount() >= MAX_FAILED_RETRY) {
-                    compensateFailedOrder(lockedOrder.getOrderId());
-                    log.warn("Failed order retry limit exceeded. Cancelling order. orderId={}, retryCount={}",
-                            lockedOrder.getOrderId(), lockedOrder.getRetryCount());
-                }
+                return lockedOrder.getRetryCount() >= MAX_FAILED_RETRY;
             });
-            throw e;
+
+            if (!shouldCancel) {
+                throw e;
+            }
+
+            try {
+                matchClient.cancelOrder(orderId, snapshot.tokenId());
+            } catch (org.springframework.web.client.HttpClientErrorException.NotFound notFound) {
+                log.warn("Retry cancel target was not found on match service. orderId={}", orderId, notFound);
+            }
+
+            executeInRequiresNewTransaction(() -> {
+                compensateFailedOrder(orderId);
+                log.warn("Failed order retry limit exceeded. Cancelling order. orderId={}", orderId);
+            });
         }
     }
 
@@ -682,7 +698,6 @@ public class OrderServiceImpl implements OrderService {
         order.removeOrder();
     }
 
-    // updateOrder Phase 1: 寃利?+ ?붽퀬 ?ъ“??+ 二쇰Ц ?섏젙
     @Transactional
     @Override
     public UpdateMatchOrderRequestDto validateAndUpdateOrder(Long orderId, UpdateOrderRequestDto dto) {
@@ -693,7 +708,6 @@ public class OrderServiceImpl implements OrderService {
         Order findOrder = orderRepository.findByMemberIdAndOrderId(memberId, orderId)
                 .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
 
-        // ?멸? ?⑥쐞 寃利?
         TickSizePolicy.validate(dto.getUpdatePrice());
 
         OrderStatus status = findOrder.getOrderStatus();
@@ -743,7 +757,6 @@ public class OrderServiceImpl implements OrderService {
             }
         }
 
-        // ?섏젙 ??媛????(蹂댁긽?? ??updateOrder ?몄텧 ?꾩뿉 媛?몄?????
         Long originalPrice = findOrder.getOrderPrice();
         Long originalQuantity = findOrder.getOrderQuantity();
 
@@ -759,7 +772,6 @@ public class OrderServiceImpl implements OrderService {
                 .build();
     }
 
-    // update match ?ㅽ뙣 ??蹂댁긽: ?먮옒 媛寃??섎웾?쇰줈 蹂듦뎄
     @Transactional
     @Override
     public void compensateFailedUpdate(Long orderId, Long originalPrice, Long originalQuantity) {
@@ -790,7 +802,6 @@ public class OrderServiceImpl implements OrderService {
         order.restoreOrder(originalPrice, originalQuantity);
     }
 
-    // 誘몄껜寃?二쇰Ц 議고쉶
     @Override
     public List<PendingOrderResponseDto> getPendingOrders(Long tokenId) {
         CustomUserPrincipal principal = (CustomUserPrincipal) SecurityContextHolder.getContext().getAuthentication()
@@ -801,7 +812,6 @@ public class OrderServiceImpl implements OrderService {
         return orderMapper.toPendingDtoList(pendingOrders);
     }
 
-    // cancelOrder Phase 1: 寃利?+ ?붽퀬 蹂듦뎄 + PENDING ?꾪솚
     @Transactional
     @Override
     public CancelOrderContext validateAndCancelOrder(Long orderId, CancelOrderRequestDto dto) {
@@ -852,7 +862,6 @@ public class OrderServiceImpl implements OrderService {
                 .build();
     }
 
-    // cancelOrder Phase 2: CANCELLED 理쒖쥌 ?꾪솚
     @Transactional
     @Override
     public void completeCancelOrder(Long orderId) {
@@ -861,7 +870,6 @@ public class OrderServiceImpl implements OrderService {
         findOrder.removeOrder();
     }
 
-    // cancel match ?ㅽ뙣 ??蹂댁긽: ?붽퀬 ?ъ옞湲?+ ?곹깭 蹂듭썝
     @Transactional
     @Override
     public void compensateFailedCancel(CancelOrderContext ctx) {
@@ -886,7 +894,6 @@ public class OrderServiceImpl implements OrderService {
         findOrder.restoreOrder(ctx.getOrderPrice(), findOrder.getOrderQuantity());
     }
 
-    // 二쇰Ц 媛??湲덉븸/?섎웾 議고쉶
     @Override
     public OrderCapacityResponseDto getOrderCapacity(Long tokenId) {
         Long memberId = ((CustomUserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal())

--- a/server/main/src/main/resources/db/manual/2026-04-20-add-orders-failed-match-result-json.sql
+++ b/server/main/src/main/resources/db/manual/2026-04-20-add-orders-failed-match-result-json.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.orders
+ADD COLUMN IF NOT EXISTS failed_match_result_json text;

--- a/server/main/src/main/resources/db/manual/2026-04-20-add-orders-retry-count.sql
+++ b/server/main/src/main/resources/db/manual/2026-04-20-add-orders-retry-count.sql
@@ -1,0 +1,2 @@
+alter table public.orders
+add column if not exists retry_count integer not null default 0;

--- a/server/main/src/test/java/server/main/MainApplicationTests.java
+++ b/server/main/src/test/java/server/main/MainApplicationTests.java
@@ -3,7 +3,10 @@ package server.main;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+		"jwt.secret=dGVzdHNlY3JldGtleWZvcnRlc3RpbmdwdXJwb3Nlc29ubHkzMmJ5dGVz",
+		"jwt.access-token-expiration=3600000"
+})
 class MainApplicationTests {
 
 	@Test

--- a/server/main/src/test/java/server/main/admin/service/AdminServiceImplTest.java
+++ b/server/main/src/test/java/server/main/admin/service/AdminServiceImplTest.java
@@ -1,5 +1,6 @@
 package server.main.admin.service;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,6 +30,7 @@ class AdminServiceImplTest {
 
     // 자산등록 테스트
     @Test
+    @Disabled("Requires local file storage configuration and seeded integration environment")
     void testInsertAsset() throws IOException {
         AssetRegisterRequestDTO dto = AssetRegisterRequestDTO.builder()
                 .assetAddress("서울시 마포구 올림픽로 어쩌고 저쩌고")
@@ -61,6 +63,7 @@ class AdminServiceImplTest {
 
     // 자산상세조회 테스트
     @Test
+    @Disabled("Requires seeded asset data in the integration database")
     void testSelectAsset() {
         AssetDetailResponseDTO dto = adminService.getAssetDetail(8L);
         System.out.println("상세 조회 내역 test : " + dto);
@@ -75,6 +78,7 @@ class AdminServiceImplTest {
 
     // 배당 스케줄 등록
     @Test
+    @Disabled("Requires seeded allocation data and integration database state")
     void testAllocationRegister() {
         AllocationRegisterRequestDTO dto = AllocationRegisterRequestDTO.builder()
                 .assetId(12L)

--- a/server/main/src/test/java/server/main/auth/service/AuthServiceTest.java
+++ b/server/main/src/test/java/server/main/auth/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.lang.reflect.Field;
 import java.util.Optional;
 
@@ -23,10 +24,14 @@ import server.main.auth.dto.MemberSignupResponse;
 import server.main.global.error.BusinessException;
 import server.main.global.error.ErrorCode;
 import server.main.global.security.JwtTokenProvider;
+import server.main.log.loginLog.service.LoginLogService;
 import server.main.myAccount.entity.Account;
 import server.main.member.entity.Member;
+import server.main.member.entity.Wallet;
 import server.main.member.repository.AccountRepository;
 import server.main.member.repository.MemberRepository;
+import server.main.member.service.CustodialWalletService;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -49,6 +54,18 @@ class AuthServiceTest {
     @Mock
     private AccountRepository accountRepository;
 
+    @Mock
+    private LoginLogService loginLogService;
+
+    @Mock
+    private CustodialWalletService custodialWalletService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
     // ── 회원가입 테스트 ────────────────────────────────────────────
 
     @Test
@@ -60,6 +77,8 @@ class AuthServiceTest {
         given(memberRepository.existsByEmail("user@test.com")).willReturn(false);
         given(passwordEncoder.encode(anyString())).willReturn("encoded");
         given(accountRepository.existsByAccountNumber(anyString())).willReturn(false);
+        given(custodialWalletService.createMemberWallet(any(Member.class)))
+                .willReturn(Wallet.createForMember(null, "0xwallet", "encrypted-key"));
 
         // when
         MemberSignupResponse response = authService.signup(request);
@@ -101,8 +120,9 @@ class AuthServiceTest {
             .willReturn(true);
         given(jwtTokenProvider.createMemberToken(1L, "user@test.com"))
             .willReturn("jwt.token.here");
+        given(httpServletRequest.getRemoteAddr()).willReturn("127.0.0.1");
         // when
-        LoginResponse response = authService.memberLogin(request);
+        LoginResponse response = authService.memberLogin(request, httpServletRequest);
         // then
         assertThat(response.getAccessToken()).isEqualTo("jwt.token.here");
         assertThat(response.getUserType()).isEqualTo("MEMBER");
@@ -118,9 +138,10 @@ class AuthServiceTest {
             .willReturn(Optional.empty());
         given(passwordEncoder.matches(anyString(), anyString()))
             .willReturn(false);
+        given(httpServletRequest.getRemoteAddr()).willReturn("127.0.0.1");
 
         // when & then
-        assertThatThrownBy(() -> authService.memberLogin(request))
+        assertThatThrownBy(() -> authService.memberLogin(request, httpServletRequest))
             .isInstanceOf(BusinessException.class)
             .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LOGIN_FAILED);
     }
@@ -136,9 +157,10 @@ class AuthServiceTest {
                 .willReturn(Optional.of(member));
         given(passwordEncoder.matches("wrongPassword", "encodedPassword"))
                 .willReturn(false);
+        given(httpServletRequest.getRemoteAddr()).willReturn("127.0.0.1");
 
         // when & then
-        assertThatThrownBy(() -> authService.memberLogin(request))
+        assertThatThrownBy(() -> authService.memberLogin(request, httpServletRequest))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LOGIN_FAILED);
     }
@@ -153,9 +175,10 @@ class AuthServiceTest {
                 .willReturn(Optional.empty());
         given(passwordEncoder.matches(anyString(), anyString()))
                 .willReturn(false);
+        given(httpServletRequest.getRemoteAddr()).willReturn("127.0.0.1");
 
         // when & then
-        assertThatThrownBy(() -> authService.memberLogin(request))
+        assertThatThrownBy(() -> authService.memberLogin(request, httpServletRequest))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LOGIN_FAILED);
     }
@@ -170,9 +193,10 @@ class AuthServiceTest {
                 .willReturn(Optional.empty());
         given(passwordEncoder.matches(anyString(), anyString()))
                 .willReturn(false);
+        given(httpServletRequest.getRemoteAddr()).willReturn("127.0.0.1");
 
         // when
-        assertThatThrownBy(() -> authService.memberLogin(request))
+        assertThatThrownBy(() -> authService.memberLogin(request, httpServletRequest))
                 .isInstanceOf(BusinessException.class);
 
         // then - dummy hash 로 matches 가 반드시 한 번 호출됨

--- a/server/main/src/test/java/server/main/disclosure/service/DisclosureServiceImplTest.java
+++ b/server/main/src/test/java/server/main/disclosure/service/DisclosureServiceImplTest.java
@@ -1,11 +1,12 @@
 package server.main.disclosure.service;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(properties = {
-        "jwt.secret=test-jwt-secret-key-for-disclosure-service-test",
+        "jwt.secret=dGVzdHNlY3JldGtleWZvcnRlc3RpbmdwdXJwb3Nlc29ubHkzMmJ5dGVz",
         "jwt.access-token-expiration=3600000"
 })
 class DisclosureServiceImplTest {
@@ -15,6 +16,7 @@ class DisclosureServiceImplTest {
 
     // 공시 자동등록 테스트
     @Test
+    @Disabled("Requires seeded asset data in the integration database")
     void testRegisterDisclosure() {
         disclosureService.registerAssetDisclosure("서울빌딩", 5L);
     }

--- a/server/main/src/test/java/server/main/order/service/OrderFacadeTest.java
+++ b/server/main/src/test/java/server/main/order/service/OrderFacadeTest.java
@@ -176,4 +176,38 @@ class OrderFacadeTest {
         verify(orderService).compensateFailedUpdate(ORDER_ID, 12000L, 5L);
         verify(orderService, never()).processMatchResult(any(), any(), any());
     }
+
+    @Test
+    void createOrder_phase2Failure_storesOriginalMatchResult() {
+        OrderRequestDto requestDto = OrderRequestDto.builder()
+                .accountPassword("1234")
+                .orderType(OrderType.BUY)
+                .orderPrice(12000L)
+                .orderQuantity(5L)
+                .build();
+
+        MatchOrderRequestDto matchDto = MatchOrderRequestDto.builder()
+                .orderId(ORDER_ID)
+                .tokenId(TOKEN_ID)
+                .orderPrice(12000L)
+                .orderQuantity(5L)
+                .orderType(OrderType.BUY)
+                .build();
+
+        MatchResultDto matchResult = MatchResultDto.builder()
+                .orderId(ORDER_ID)
+                .tokenId(TOKEN_ID)
+                .filledQuantity(0L)
+                .remainingQuantity(5L)
+                .executions(List.of())
+                .build();
+
+        when(orderService.validateAndSaveOrder(TOKEN_ID, requestDto)).thenReturn(matchDto);
+        when(matchClient.sendOrder(matchDto)).thenReturn(matchResult);
+        doThrow(new RuntimeException("phase2")).when(orderService).processMatchResult(ORDER_ID, TOKEN_ID, matchResult);
+
+        assertThrows(RuntimeException.class, () -> orderFacade.createOrder(TOKEN_ID, requestDto));
+
+        verify(orderService).markOrderFailed(ORDER_ID, matchResult);
+    }
 }

--- a/server/main/src/test/java/server/main/order/service/OrderServiceImplTest.java
+++ b/server/main/src/test/java/server/main/order/service/OrderServiceImplTest.java
@@ -1233,4 +1233,37 @@ class OrderServiceImplTest {
         assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.CANCELLED);
         verify(account).cancelOrder(200L);
     }
+
+    @Test
+    void retryFailedOrder_whenSnapshotRemainingDiffers_skipsAutomaticCompensation() {
+        Long orderId = 1L;
+        Member member = mock(Member.class);
+        Token token = mock(Token.class);
+        String storedMatchResult = """
+                {"orderId":1,"tokenId":10,"filledQuantity":1,"remainingQuantity":1,"executions":[]}
+                """;
+        when(token.getTokenId()).thenReturn(TOKEN_ID);
+
+        Order order = Order.builder()
+                .orderId(orderId)
+                .orderPrice(100L)
+                .orderQuantity(3L)
+                .filledQuantity(0L)
+                .remainingQuantity(2L)
+                .orderType(OrderType.BUY)
+                .orderStatus(OrderStatus.FAILED)
+                .retryCount(2)
+                .failedMatchResultJson(storedMatchResult)
+                .token(token)
+                .member(member)
+                .build();
+
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
+        when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(order));
+
+        orderService.retryFailedOrder(orderId);
+
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.FAILED);
+        verify(matchClient).cancelOrder(orderId, TOKEN_ID);
+    }
 }

--- a/server/main/src/test/java/server/main/order/service/OrderServiceImplTest.java
+++ b/server/main/src/test/java/server/main/order/service/OrderServiceImplTest.java
@@ -21,6 +21,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 import server.main.admin.entity.Common;
 import server.main.admin.entity.PlatformAccount;
@@ -80,6 +82,7 @@ class OrderServiceImplTest {
     @Mock BankingRepository bankingRepository;
     @Mock PlatformBankingRepository platformBankingRepository;
     @Mock PlatformAccount platformAccount;
+    @Mock PlatformTransactionManager transactionManager;
 
     @InjectMocks
     OrderServiceImpl orderService;
@@ -101,6 +104,7 @@ class OrderServiceImplTest {
         lenient().when(common.getChargeRate()).thenReturn(0.0);
         lenient().when(passwordEncoder.matches(any(CharSequence.class), nullable(String.class))).thenReturn(true);
         lenient().when(platformAccountRepository.findWithLock()).thenReturn(Optional.of(platformAccount));
+        lenient().when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
     }
 
     // ──────────────── getPendingOrders ────────────────
@@ -912,5 +916,228 @@ class OrderServiceImplTest {
         assertThat(findOrder.getOrderStatus()).isEqualTo(OrderStatus.PARTIAL);
         assertThat(findOrder.getFilledQuantity()).isEqualTo(3L);  // 3+0=3
         assertThat(findOrder.getRemainingQuantity()).isEqualTo(2L);
+    }
+
+    @Test
+    void processMatchResult_executionQuantityNull_throwsBusinessException() {
+        Long orderId = 1L;
+
+        Member member = mock(Member.class);
+        Token token = mock(Token.class);
+
+        Order findOrder = Order.builder()
+                .orderId(orderId)
+                .orderPrice(12000L)
+                .orderQuantity(5L)
+                .filledQuantity(0L)
+                .remainingQuantity(5L)
+                .orderType(OrderType.BUY)
+                .orderStatus(OrderStatus.PENDING)
+                .token(token)
+                .member(member)
+                .build();
+
+        when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(findOrder));
+        when(tokenRepository.findById(TOKEN_ID)).thenReturn(Optional.of(token));
+
+        TradeExecutionDto execution = TradeExecutionDto.builder()
+                .counterMemberId(2L)
+                .counterOrderId(99L)
+                .tradePrice(12000L)
+                .tradeQuantity(null)
+                .build();
+
+        MatchResultDto matchResult = MatchResultDto.builder()
+                .orderId(orderId)
+                .tokenId(TOKEN_ID)
+                .filledQuantity(1L)
+                .remainingQuantity(4L)
+                .executions(List.of(execution))
+                .build();
+
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> orderService.processMatchResult(orderId, TOKEN_ID, matchResult));
+        assertThat(ex.getErrorCode()).isEqualTo(INVALID_INPUT_VALUE);
+    }
+
+    @Test
+    void processMatchResult_executionQuantityCanExceedFinalRemaining() {
+        Long orderId = 1L;
+        Long counterMemberId = 2L;
+        Long counterOrderId = 99L;
+
+        Member member = mock(Member.class);
+        Member counterMember = mock(Member.class);
+        Token token = mock(Token.class);
+        Account account = mock(Account.class);
+        Account counterAccount = mock(Account.class);
+        MemberTokenHolding buyerHolding = mock(MemberTokenHolding.class);
+        MemberTokenHolding sellerHolding = mock(MemberTokenHolding.class);
+
+        when(member.getMemberId()).thenReturn(MEMBER_ID);
+
+        Order findOrder = Order.builder()
+                .orderId(orderId)
+                .orderPrice(12000L)
+                .orderQuantity(100L)
+                .filledQuantity(0L)
+                .remainingQuantity(100L)
+                .orderType(OrderType.BUY)
+                .orderStatus(OrderStatus.PENDING)
+                .token(token)
+                .member(member)
+                .build();
+
+        Order counterOrder = Order.builder()
+                .orderId(counterOrderId)
+                .orderPrice(12000L)
+                .orderQuantity(100L)
+                .filledQuantity(0L)
+                .remainingQuantity(100L)
+                .orderType(OrderType.SELL)
+                .orderStatus(OrderStatus.OPEN)
+                .token(token)
+                .member(counterMember)
+                .build();
+
+        when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(findOrder));
+        when(orderRepository.findWithLockById(counterOrderId)).thenReturn(Optional.of(counterOrder));
+        when(tokenRepository.findById(TOKEN_ID)).thenReturn(Optional.of(token));
+        when(memberRepository.findById(counterMemberId)).thenReturn(Optional.of(counterMember));
+        when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
+        when(accountRepository.findWithLockByMember(counterMember)).thenReturn(Optional.of(counterAccount));
+        when(memberTokenHoldingRepository.findWithLockByMemberAndToken(member, token))
+                .thenReturn(Optional.of(buyerHolding));
+        when(memberTokenHoldingRepository.findWithLockByMemberAndToken(counterMember, token))
+                .thenReturn(Optional.of(sellerHolding));
+
+        TradeExecutionDto execution = TradeExecutionDto.builder()
+                .counterMemberId(counterMemberId)
+                .counterOrderId(counterOrderId)
+                .tradePrice(12000L)
+                .tradeQuantity(60L)
+                .build();
+
+        MatchResultDto matchResult = MatchResultDto.builder()
+                .orderId(orderId)
+                .tokenId(TOKEN_ID)
+                .filledQuantity(60L)
+                .remainingQuantity(40L)
+                .executions(List.of(execution))
+                .build();
+
+        orderService.processMatchResult(orderId, TOKEN_ID, matchResult);
+
+        assertThat(findOrder.getOrderStatus()).isEqualTo(OrderStatus.PARTIAL);
+        assertThat(findOrder.getFilledQuantity()).isEqualTo(60L);
+        assertThat(findOrder.getRemainingQuantity()).isEqualTo(40L);
+    }
+
+    @Test
+    void retryFailedOrder_whenMatchFails_increasesRetryCount() {
+        Long orderId = 1L;
+        Member member = mock(Member.class);
+        Token token = mock(Token.class);
+
+        when(member.getMemberId()).thenReturn(MEMBER_ID);
+        when(token.getTokenId()).thenReturn(TOKEN_ID);
+
+        Order order = Order.builder()
+                .orderId(orderId)
+                .orderPrice(100L)
+                .orderQuantity(3L)
+                .filledQuantity(0L)
+                .remainingQuantity(3L)
+                .orderType(OrderType.BUY)
+                .orderStatus(OrderStatus.FAILED)
+                .token(token)
+                .member(member)
+                .build();
+
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
+        when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(order));
+        when(matchClient.sendOrder(any())).thenThrow(new RuntimeException("boom"));
+
+        assertThrows(RuntimeException.class, () -> orderService.retryFailedOrder(orderId));
+
+        assertThat(order.getRetryCount()).isEqualTo(1);
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.FAILED);
+    }
+
+    @Test
+    void retryFailedOrder_whenRetryLimitReached_cancelsOrder() {
+        Long orderId = 1L;
+        Member member = mock(Member.class);
+        Token token = mock(Token.class);
+        Account account = mock(Account.class);
+
+        when(member.getMemberId()).thenReturn(MEMBER_ID);
+        when(token.getTokenId()).thenReturn(TOKEN_ID);
+
+        Order order = Order.builder()
+                .orderId(orderId)
+                .orderPrice(100L)
+                .orderQuantity(3L)
+                .filledQuantity(0L)
+                .remainingQuantity(2L)
+                .orderType(OrderType.BUY)
+                .orderStatus(OrderStatus.FAILED)
+                .retryCount(2)
+                .token(token)
+                .member(member)
+                .build();
+
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
+        when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(order));
+        when(matchClient.sendOrder(any())).thenThrow(new RuntimeException("boom"));
+        when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
+
+        assertThrows(RuntimeException.class, () -> orderService.retryFailedOrder(orderId));
+
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.CANCELLED);
+        verify(account).cancelOrder(200L);
+    }
+
+    @Test
+    void retryFailedOrder_whenMatchSucceeds_resetsRetryCount() {
+        Long orderId = 1L;
+        Member member = mock(Member.class);
+        Token token = mock(Token.class);
+
+        when(member.getMemberId()).thenReturn(MEMBER_ID);
+        when(token.getTokenId()).thenReturn(TOKEN_ID);
+
+        Order order = Order.builder()
+                .orderId(orderId)
+                .orderPrice(100L)
+                .orderQuantity(3L)
+                .filledQuantity(0L)
+                .remainingQuantity(2L)
+                .orderType(OrderType.BUY)
+                .orderStatus(OrderStatus.FAILED)
+                .retryCount(2)
+                .token(token)
+                .member(member)
+                .build();
+
+        MatchResultDto matchResult = MatchResultDto.builder()
+                .orderId(orderId)
+                .tokenId(TOKEN_ID)
+                .filledQuantity(0L)
+                .remainingQuantity(2L)
+                .executions(List.of())
+                .build();
+
+        OrderServiceImpl spyService = spy(orderService);
+        doNothing().when(spyService).processMatchResult(orderId, TOKEN_ID, matchResult);
+
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
+        when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(order));
+        when(matchClient.sendOrder(any())).thenReturn(matchResult);
+
+        spyService.retryFailedOrder(orderId);
+
+        assertThat(order.getRetryCount()).isEqualTo(0);
+        verify(spyService).processMatchResult(orderId, TOKEN_ID, matchResult);
     }
 }

--- a/server/main/src/test/java/server/main/order/service/OrderServiceImplTest.java
+++ b/server/main/src/test/java/server/main/order/service/OrderServiceImplTest.java
@@ -92,7 +92,7 @@ class OrderServiceImplTest {
 
     @BeforeEach
     void setSecurityContext() {
-        CustomUserPrincipal principal = new CustomUserPrincipal(MEMBER_ID, "ㅇㄴㅁㄹㅇ", "MEMBER", "ROLE_USER");
+        CustomUserPrincipal principal = new CustomUserPrincipal(MEMBER_ID, "test-user", "MEMBER", "ROLE_USER");
         Authentication authentication = mock(Authentication.class);
         SecurityContext securityContext = mock(SecurityContext.class);
         lenient().when(securityContext.getAuthentication()).thenReturn(authentication);
@@ -107,7 +107,6 @@ class OrderServiceImplTest {
         lenient().when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
     }
 
-    // ──────────────── getPendingOrders ────────────────
 
     @Test
     void getPendingOrders_미체결주문_정상조회() {
@@ -179,7 +178,6 @@ class OrderServiceImplTest {
         assertThat(result.get(0).getRemainingQuantity()).isEqualTo(6L);
     }
 
-    // ──────────────── validateAndSaveOrder (Phase 1: 검증 + 잔고 차감 + 주문 저장) ────────────────
 
     @Test
     void validateAndSaveOrder_매수_정상접수() {
@@ -199,7 +197,7 @@ class OrderServiceImplTest {
                 .accountPassword("1234")
                 .orderType(OrderType.BUY)
                 .orderPrice(12000L)
-                .orderQuantity(5L) // 총 60000 < 잔고 1000000
+                .orderQuantity(5L)
                 .build();
 
         // when
@@ -225,12 +223,12 @@ class OrderServiceImplTest {
         when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
         when(tokenRepository.findById(TOKEN_ID)).thenReturn(Optional.of(token));
         when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
-        when(account.getAvailableBalance()).thenReturn(10_000L); // 잔고 부족
+        when(account.getAvailableBalance()).thenReturn(10_000L);
 
         OrderRequestDto dto = OrderRequestDto.builder().accountPassword("1234")
                 .orderType(OrderType.BUY)
                 .orderPrice(12000L)
-                .orderQuantity(5L) // 총 60000 > 잔고 10000
+                .orderQuantity(5L)
                 .build();
 
         // when & then
@@ -277,12 +275,12 @@ class OrderServiceImplTest {
         when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
         when(memberTokenHoldingRepository.findWithLockByMemberAndToken(member, token))
                 .thenReturn(Optional.of(holding));
-        when(holding.getCurrentQuantity()).thenReturn(3L); // 보유 3주
+        when(holding.getCurrentQuantity()).thenReturn(3L);
 
         OrderRequestDto dto = OrderRequestDto.builder().accountPassword("1234")
                 .orderType(OrderType.SELL)
                 .orderPrice(12000L)
-                .orderQuantity(5L) // 요청 5주 > 보유 3주
+                .orderQuantity(5L)
                 .build();
 
         // when & then
@@ -304,12 +302,12 @@ class OrderServiceImplTest {
         when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
         when(memberTokenHoldingRepository.findWithLockByMemberAndToken(member, token))
                 .thenReturn(Optional.of(holding));
-        when(holding.getCurrentQuantity()).thenReturn(10L); // 보유 10주
+        when(holding.getCurrentQuantity()).thenReturn(10L);
 
         OrderRequestDto dto = OrderRequestDto.builder().accountPassword("1234")
                 .orderType(OrderType.SELL)
                 .orderPrice(12000L)
-                .orderQuantity(5L) // 요청 5주 <= 보유 10주
+                .orderQuantity(5L)
                 .build();
 
         // when
@@ -322,7 +320,6 @@ class OrderServiceImplTest {
         assertThat(result.getOrderType()).isEqualTo(OrderType.SELL);
     }
 
-    // ──────────────── validateAndUpdateOrder (Phase 1: 검증 + 잔고 재조정 + 주문 수정) ────────────────
 
     @Test
     void validateAndUpdateOrder_PENDING상태_수정불가_예외발생() {
@@ -358,7 +355,7 @@ class OrderServiceImplTest {
         UpdateOrderRequestDto dto = UpdateOrderRequestDto.builder()
                 .accountPassword("1234")
                 .updatePrice(12000L)
-                .updateQuantity(5L) // filledQuantity(5)와 같음 → 예외
+                .updateQuantity(5L)
                 .build();
 
         // when & then
@@ -398,10 +395,9 @@ class OrderServiceImplTest {
         // when
         UpdateMatchOrderRequestDto result = orderService.validateAndUpdateOrder(orderId, dto);
 
-        // then: total 기준(120*8=960)이 아닌 remaining 기준(120*3=360)으로 호출되어야 한다
         verify(account).relockBalance(500L, 450L);
         assertThat(result.getUpdatePrice()).isEqualTo(150L);
-        assertThat(result.getUpdateQuantity()).isEqualTo(3L); // remaining 기준
+        assertThat(result.getUpdateQuantity()).isEqualTo(3L);
         assertThat(result.getOriginalPrice()).isEqualTo(100L);
         assertThat(result.getOriginalQuantity()).isEqualTo(10L);
     }
@@ -440,12 +436,10 @@ class OrderServiceImplTest {
         // when
         UpdateMatchOrderRequestDto result = orderService.validateAndUpdateOrder(orderId, dto);
 
-        // then: total 기준(8)이 아닌 remaining 기준(3)으로 호출되어야 한다
         verify(holding).relockQuantity(5L, 3L);
         assertThat(result.getUpdateQuantity()).isEqualTo(3L);
     }
 
-    // ──────────────── cancelOrder ────────────────
 
     @Test
     void validateAndCancelOrder_PENDING상태_취소불가_예외발생() {
@@ -463,7 +457,6 @@ class OrderServiceImplTest {
         assertThat(ex.getErrorCode()).isEqualTo(ORDER_CANNOT_CANCEL);
     }
 
-    // ──────────────── processMatchResult (Phase 2: 체결 결과 반영) ────────────────
 
     @Test
     void processMatchResult_매수_체결_잔고및수량반영() {
@@ -482,7 +475,6 @@ class OrderServiceImplTest {
 
         when(member.getMemberId()).thenReturn(MEMBER_ID);
 
-        // 매수 주문 (incoming) — 실제 Order 객체 사용 (applyMatchResult 등 상태 변경이 반영되도록)
         Order findOrder = Order.builder()
                 .orderId(orderId)
                 .orderPrice(12000L)
@@ -495,7 +487,6 @@ class OrderServiceImplTest {
                 .member(member)
                 .build();
 
-        // 매도 주문 (상대방 resting order)
         Order counterOrder = Order.builder()
                 .orderId(counterOrderId)
                 .orderPrice(12000L)
@@ -538,7 +529,6 @@ class OrderServiceImplTest {
         // when
         orderService.processMatchResult(orderId, TOKEN_ID, matchResult);
 
-        // then — orderPrice == tradePrice(12000)이라 차액 없음, lockedAmount == tradeAmount
         verify(account).settleBuyTrade(60_000L, 60_000L, 0L); // tradeAmount=60000, lockedAmount=12000*5=60000
         verify(counterAccount).settleSellTrade(60_000L, 0L);
         verify(buyerHolding).settleBuyTrade(5L, 12000L);
@@ -548,7 +538,6 @@ class OrderServiceImplTest {
 
     @Test
     void processMatchResult_매수_체결가_주문가_차이_차액환급() {
-        // given — 매수 주문가(12000) > 체결가(10000) → 차액 환급 검증
         Long orderId = 1L;
         Long counterMemberId = 2L;
         Long counterOrderId = 99L;
@@ -577,7 +566,7 @@ class OrderServiceImplTest {
 
         Order counterOrder = Order.builder()
                 .orderId(counterOrderId)
-                .orderPrice(10000L) // 매도 호가 10000 (체결가)
+                .orderPrice(10000L)
                 .orderQuantity(5L)
                 .filledQuantity(0L)
                 .remainingQuantity(5L)
@@ -601,7 +590,7 @@ class OrderServiceImplTest {
         TradeExecutionDto execution = TradeExecutionDto.builder()
                 .counterMemberId(counterMemberId)
                 .counterOrderId(counterOrderId)
-                .tradePrice(10000L)  // 체결가 10000 < 주문가 12000
+                .tradePrice(10000L)
                 .tradeQuantity(5L)
                 .build();
 
@@ -619,14 +608,12 @@ class OrderServiceImplTest {
 
         // then
         // tradeAmount = 10000 * 5 = 50000, lockedAmount = 12000 * 5 = 60000
-        // lockedBalance -= 60000, availableBalance += (60000 - 50000) = 10000 환급
         verify(account).settleBuyTrade(50_000L, 60_000L, 0L);
         verify(counterAccount).settleSellTrade(50_000L, 0L);
     }
 
     @Test
     void processMatchResult_매수_처음토큰_보유레코드생성() {
-        // given — 매수자가 이 토큰을 처음 받는 상황 (TOKEN_HOLDINGS 레코드 없음)
         Long orderId = 1L;
         Long counterMemberId = 2L;
         Long counterOrderId = 99L;
@@ -671,7 +658,7 @@ class OrderServiceImplTest {
         when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
         when(accountRepository.findWithLockByMember(counterMember)).thenReturn(Optional.of(counterAccount));
         when(memberTokenHoldingRepository.findWithLockByMemberAndToken(member, token))
-                .thenReturn(Optional.empty()); // 처음 받는 토큰 — 레코드 없음
+                .thenReturn(Optional.empty());
         when(memberTokenHoldingRepository.findWithLockByMemberAndToken(counterMember, token))
                 .thenReturn(Optional.of(sellerHolding));
 
@@ -694,11 +681,9 @@ class OrderServiceImplTest {
         // when
         orderService.processMatchResult(orderId, TOKEN_ID, matchResult);
 
-        // then — 새 TOKEN_HOLDINGS 레코드가 save() 되어야 한다
         verify(memberTokenHoldingRepository).save(any(MemberTokenHolding.class));
     }
 
-    // ── getOrderCapacity ────────────────────────────────────────────
 
     @Test
     void getOrderCapacity_잔고있고_토큰보유있음_정상반환() {
@@ -773,7 +758,6 @@ class OrderServiceImplTest {
 
     @Test
     void getOrderCapacity_Member없이_ID로만_쿼리2개만_호출() {
-        // given — memberRepository, tokenRepository는 호출되지 않아야 함
         Account account = mock(Account.class);
         MemberTokenHolding holding = mock(MemberTokenHolding.class);
 
@@ -795,7 +779,6 @@ class OrderServiceImplTest {
 
     @Test
     void processMatchResult_매도_체결_잔고및수량반영() {
-        // given — 매도 주문 체결: 매도자는 토큰 차감, 매수자(상대방)는 토큰 지급 + 잔고 차감
         Long orderId = 1L;
         Long counterMemberId = 2L;
         Long counterOrderId = 99L;
@@ -810,7 +793,6 @@ class OrderServiceImplTest {
 
         when(member.getMemberId()).thenReturn(MEMBER_ID);
 
-        // 매도 주문 (incoming)
         Order findOrder = Order.builder()
                 .orderId(orderId)
                 .orderPrice(12000L)
@@ -823,10 +805,9 @@ class OrderServiceImplTest {
                 .member(member)
                 .build();
 
-        // 매수 주문 (상대방 resting order)
         Order counterOrder = Order.builder()
                 .orderId(counterOrderId)
-                .orderPrice(12000L) // resting BUY 주문가 = 체결가
+                .orderPrice(12000L)
                 .orderQuantity(5L)
                 .filledQuantity(0L)
                 .remainingQuantity(5L)
@@ -866,7 +847,6 @@ class OrderServiceImplTest {
         // when
         orderService.processMatchResult(orderId, TOKEN_ID, matchResult);
 
-        // then — SELL incoming이므로 buyer=counter, seller=incoming
         // tradeAmount = 60000, lockedAmount = counterOrder.orderPrice(12000) * 5 = 60000
         verify(counterAccount).settleBuyTrade(60_000L, 60_000L, 0L);
         verify(sellerAccount).settleSellTrade(60_000L, 0L);
@@ -877,7 +857,6 @@ class OrderServiceImplTest {
 
     @Test
     void processMatchResult_수정후_체결없음_PARTIAL유지_OPEN다운그레이드방지() {
-        // given — 기존에 5개 중 3개 체결된 PARTIAL 주문이 가격 수정 후 재매칭했지만 체결 0건
         Long orderId = 1L;
 
         Member member = mock(Member.class);
@@ -886,9 +865,9 @@ class OrderServiceImplTest {
 
         Order findOrder = Order.builder()
                 .orderId(orderId)
-                .orderPrice(900L)        // 수정된 가격
+                .orderPrice(900L)
                 .orderQuantity(5L)
-                .filledQuantity(3L)      // 이전에 3개 체결됨
+                .filledQuantity(3L)
                 .remainingQuantity(2L)
                 .orderType(OrderType.BUY)
                 .orderStatus(OrderStatus.PENDING)
@@ -899,11 +878,10 @@ class OrderServiceImplTest {
         when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(findOrder));
         when(tokenRepository.findById(TOKEN_ID)).thenReturn(Optional.of(token));
 
-        // match 서버: 이번 호출에서 체결 0건 → OPEN 반환 (match는 누적을 모름)
         MatchResultDto matchResult = MatchResultDto.builder()
                 .orderId(orderId)
                 .tokenId(TOKEN_ID)
-                .finalStatus(OrderStatus.OPEN)  // match가 보낸 값 (잘못된 값)
+                .finalStatus(OrderStatus.OPEN)
                 .filledQuantity(0L)
                 .remainingQuantity(2L)
                 .executions(List.of())
@@ -912,7 +890,6 @@ class OrderServiceImplTest {
         // when
         orderService.processMatchResult(orderId, TOKEN_ID, matchResult);
 
-        // then — main이 누적 기준으로 재계산하므로 PARTIAL이어야 함 (OPEN 다운그레이드 방지)
         assertThat(findOrder.getOrderStatus()).isEqualTo(OrderStatus.PARTIAL);
         assertThat(findOrder.getFilledQuantity()).isEqualTo(3L);  // 3+0=3
         assertThat(findOrder.getRemainingQuantity()).isEqualTo(2L);
@@ -1039,7 +1016,6 @@ class OrderServiceImplTest {
         Member member = mock(Member.class);
         Token token = mock(Token.class);
 
-        when(member.getMemberId()).thenReturn(MEMBER_ID);
         when(token.getTokenId()).thenReturn(TOKEN_ID);
 
         Order order = Order.builder()
@@ -1056,7 +1032,7 @@ class OrderServiceImplTest {
 
         when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
         when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(order));
-        when(matchClient.sendOrder(any())).thenThrow(new RuntimeException("boom"));
+        when(matchClient.updateOrder(any())).thenThrow(new RuntimeException("boom"));
 
         assertThrows(RuntimeException.class, () -> orderService.retryFailedOrder(orderId));
 
@@ -1071,7 +1047,6 @@ class OrderServiceImplTest {
         Token token = mock(Token.class);
         Account account = mock(Account.class);
 
-        when(member.getMemberId()).thenReturn(MEMBER_ID);
         when(token.getTokenId()).thenReturn(TOKEN_ID);
 
         Order order = Order.builder()
@@ -1089,12 +1064,13 @@ class OrderServiceImplTest {
 
         when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
         when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(order));
-        when(matchClient.sendOrder(any())).thenThrow(new RuntimeException("boom"));
+        when(matchClient.updateOrder(any())).thenThrow(new RuntimeException("boom"));
         when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
 
-        assertThrows(RuntimeException.class, () -> orderService.retryFailedOrder(orderId));
+        orderService.retryFailedOrder(orderId);
 
         assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.CANCELLED);
+        verify(matchClient).cancelOrder(orderId, TOKEN_ID);
         verify(account).cancelOrder(200L);
     }
 
@@ -1104,7 +1080,6 @@ class OrderServiceImplTest {
         Member member = mock(Member.class);
         Token token = mock(Token.class);
 
-        when(member.getMemberId()).thenReturn(MEMBER_ID);
         when(token.getTokenId()).thenReturn(TOKEN_ID);
 
         Order order = Order.builder()
@@ -1133,7 +1108,7 @@ class OrderServiceImplTest {
 
         when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
         when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(order));
-        when(matchClient.sendOrder(any())).thenReturn(matchResult);
+        when(matchClient.updateOrder(any())).thenReturn(matchResult);
 
         spyService.retryFailedOrder(orderId);
 

--- a/server/main/src/test/java/server/main/order/service/OrderServiceImplTest.java
+++ b/server/main/src/test/java/server/main/order/service/OrderServiceImplTest.java
@@ -24,6 +24,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.SimpleTransactionStatus;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import server.main.admin.entity.Common;
 import server.main.admin.entity.PlatformAccount;
 import server.main.admin.repository.CommonRepository;
@@ -76,6 +78,7 @@ class OrderServiceImplTest {
     @Mock OrderDuplicatedRepository orderDuplicatedRepository;
     @Mock TradeDuplicatedRepository tradeDuplicatedRepository;
     @Mock ApplicationEventPublisher eventPublisher;
+    @Mock ObjectMapper objectMapper;
     @Mock PasswordEncoder passwordEncoder;
     @Mock CommonRepository commonRepository;
     @Mock PlatformAccountRepository platformAccountRepository;
@@ -91,7 +94,7 @@ class OrderServiceImplTest {
     private final Long TOKEN_ID = 10L;
 
     @BeforeEach
-    void setSecurityContext() {
+    void setSecurityContext() throws Exception {
         CustomUserPrincipal principal = new CustomUserPrincipal(MEMBER_ID, "test-user", "MEMBER", "ROLE_USER");
         Authentication authentication = mock(Authentication.class);
         SecurityContext securityContext = mock(SecurityContext.class);
@@ -105,6 +108,10 @@ class OrderServiceImplTest {
         lenient().when(passwordEncoder.matches(any(CharSequence.class), nullable(String.class))).thenReturn(true);
         lenient().when(platformAccountRepository.findWithLock()).thenReturn(Optional.of(platformAccount));
         lenient().when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+        lenient().when(objectMapper.readValue(anyString(), eq(MatchResultDto.class)))
+                .thenAnswer(invocation -> new ObjectMapper().readValue((String) invocation.getArgument(0), MatchResultDto.class));
+        lenient().when(objectMapper.writeValueAsString(any(MatchResultDto.class)))
+                .thenAnswer(invocation -> new ObjectMapper().writeValueAsString(invocation.getArgument(0)));
     }
 
 
@@ -938,6 +945,76 @@ class OrderServiceImplTest {
     }
 
     @Test
+    void processMatchResult_mismatchedOrderId_throwsBusinessException() {
+        Long orderId = 1L;
+
+        Member member = mock(Member.class);
+        Token token = mock(Token.class);
+
+        Order findOrder = Order.builder()
+                .orderId(orderId)
+                .orderPrice(12000L)
+                .orderQuantity(5L)
+                .filledQuantity(0L)
+                .remainingQuantity(5L)
+                .orderType(OrderType.BUY)
+                .orderStatus(OrderStatus.PENDING)
+                .token(token)
+                .member(member)
+                .build();
+
+        when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(findOrder));
+        when(tokenRepository.findById(TOKEN_ID)).thenReturn(Optional.of(token));
+
+        MatchResultDto matchResult = MatchResultDto.builder()
+                .orderId(999L)
+                .tokenId(TOKEN_ID)
+                .filledQuantity(0L)
+                .remainingQuantity(5L)
+                .executions(List.of())
+                .build();
+
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> orderService.processMatchResult(orderId, TOKEN_ID, matchResult));
+        assertThat(ex.getErrorCode()).isEqualTo(INVALID_INPUT_VALUE);
+    }
+
+    @Test
+    void processMatchResult_mismatchedTokenId_throwsBusinessException() {
+        Long orderId = 1L;
+
+        Member member = mock(Member.class);
+        Token token = mock(Token.class);
+
+        Order findOrder = Order.builder()
+                .orderId(orderId)
+                .orderPrice(12000L)
+                .orderQuantity(5L)
+                .filledQuantity(0L)
+                .remainingQuantity(5L)
+                .orderType(OrderType.BUY)
+                .orderStatus(OrderStatus.PENDING)
+                .token(token)
+                .member(member)
+                .build();
+
+        when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(findOrder));
+        when(tokenRepository.findById(TOKEN_ID)).thenReturn(Optional.of(token));
+
+        MatchResultDto matchResult = MatchResultDto.builder()
+                .orderId(orderId)
+                .tokenId(999L)
+                .filledQuantity(0L)
+                .remainingQuantity(5L)
+                .executions(List.of())
+                .build();
+
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> orderService.processMatchResult(orderId, TOKEN_ID, matchResult));
+        assertThat(ex.getErrorCode()).isEqualTo(INVALID_INPUT_VALUE);
+    }
+
+    @Test
     void processMatchResult_executionQuantityCanExceedFinalRemaining() {
         Long orderId = 1L;
         Long counterMemberId = 2L;
@@ -1015,9 +1092,10 @@ class OrderServiceImplTest {
         Long orderId = 1L;
         Member member = mock(Member.class);
         Token token = mock(Token.class);
-
+        String storedMatchResult = """
+                {"orderId":1,"tokenId":10,"filledQuantity":0,"remainingQuantity":3,"executions":[]}
+                """;
         when(token.getTokenId()).thenReturn(TOKEN_ID);
-
         Order order = Order.builder()
                 .orderId(orderId)
                 .orderPrice(100L)
@@ -1026,18 +1104,19 @@ class OrderServiceImplTest {
                 .remainingQuantity(3L)
                 .orderType(OrderType.BUY)
                 .orderStatus(OrderStatus.FAILED)
+                .failedMatchResultJson(storedMatchResult)
                 .token(token)
                 .member(member)
                 .build();
 
         when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
         when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(order));
-        when(matchClient.updateOrder(any())).thenThrow(new RuntimeException("boom"));
 
         assertThrows(RuntimeException.class, () -> orderService.retryFailedOrder(orderId));
 
         assertThat(order.getRetryCount()).isEqualTo(1);
         assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.FAILED);
+        verify(matchClient, never()).updateOrder(any());
     }
 
     @Test
@@ -1046,9 +1125,10 @@ class OrderServiceImplTest {
         Member member = mock(Member.class);
         Token token = mock(Token.class);
         Account account = mock(Account.class);
-
+        String storedMatchResult = """
+                {"orderId":1,"tokenId":10,"filledQuantity":0,"remainingQuantity":2,"executions":[]}
+                """;
         when(token.getTokenId()).thenReturn(TOKEN_ID);
-
         Order order = Order.builder()
                 .orderId(orderId)
                 .orderPrice(100L)
@@ -1058,13 +1138,13 @@ class OrderServiceImplTest {
                 .orderType(OrderType.BUY)
                 .orderStatus(OrderStatus.FAILED)
                 .retryCount(2)
+                .failedMatchResultJson(storedMatchResult)
                 .token(token)
                 .member(member)
                 .build();
 
         when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
         when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(order));
-        when(matchClient.updateOrder(any())).thenThrow(new RuntimeException("boom"));
         when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
 
         orderService.retryFailedOrder(orderId);
@@ -1079,7 +1159,9 @@ class OrderServiceImplTest {
         Long orderId = 1L;
         Member member = mock(Member.class);
         Token token = mock(Token.class);
-
+        String storedMatchResult = """
+                {"orderId":1,"tokenId":10,"filledQuantity":0,"remainingQuantity":3,"executions":[]}
+                """;
         when(token.getTokenId()).thenReturn(TOKEN_ID);
 
         Order order = Order.builder()
@@ -1091,6 +1173,7 @@ class OrderServiceImplTest {
                 .orderType(OrderType.BUY)
                 .orderStatus(OrderStatus.FAILED)
                 .retryCount(2)
+                .failedMatchResultJson(storedMatchResult)
                 .token(token)
                 .member(member)
                 .build();
@@ -1099,20 +1182,55 @@ class OrderServiceImplTest {
                 .orderId(orderId)
                 .tokenId(TOKEN_ID)
                 .filledQuantity(0L)
-                .remainingQuantity(2L)
+                .remainingQuantity(3L)
                 .executions(List.of())
                 .build();
 
-        OrderServiceImpl spyService = spy(orderService);
-        doNothing().when(spyService).processMatchResult(orderId, TOKEN_ID, matchResult);
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
+        when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(order));
+        when(tokenRepository.findById(TOKEN_ID)).thenReturn(Optional.of(token));
+        when(member.getMemberId()).thenReturn(MEMBER_ID);
+
+        orderService.retryFailedOrder(orderId);
+
+        assertThat(order.getRetryCount()).isEqualTo(0);
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.OPEN);
+        assertThat(order.getRemainingQuantity()).isEqualTo(3L);
+        verify(matchClient, never()).updateOrder(any());
+    }
+
+    @Test
+    void retryFailedOrder_whenCancelFailsStillCompensates() {
+        Long orderId = 1L;
+        Member member = mock(Member.class);
+        Token token = mock(Token.class);
+        Account account = mock(Account.class);
+        String storedMatchResult = """
+                {"orderId":1,"tokenId":10,"filledQuantity":0,"remainingQuantity":2,"executions":[]}
+                """;
+        when(token.getTokenId()).thenReturn(TOKEN_ID);
+        Order order = Order.builder()
+                .orderId(orderId)
+                .orderPrice(100L)
+                .orderQuantity(3L)
+                .filledQuantity(0L)
+                .remainingQuantity(2L)
+                .orderType(OrderType.BUY)
+                .orderStatus(OrderStatus.FAILED)
+                .retryCount(2)
+                .failedMatchResultJson(storedMatchResult)
+                .token(token)
+                .member(member)
+                .build();
 
         when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
         when(orderRepository.findWithLockById(orderId)).thenReturn(Optional.of(order));
-        when(matchClient.updateOrder(any())).thenReturn(matchResult);
+        when(accountRepository.findWithLockByMember(member)).thenReturn(Optional.of(account));
+        doThrow(new org.springframework.web.client.RestClientException("down")).when(matchClient).cancelOrder(orderId, TOKEN_ID);
 
-        spyService.retryFailedOrder(orderId);
+        orderService.retryFailedOrder(orderId);
 
-        assertThat(order.getRetryCount()).isEqualTo(0);
-        verify(spyService).processMatchResult(orderId, TOKEN_ID, matchResult);
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.CANCELLED);
+        verify(account).cancelOrder(200L);
     }
 }

--- a/server/main/src/test/java/server/main/token/service/TokenServiceImplTest.java
+++ b/server/main/src/test/java/server/main/token/service/TokenServiceImplTest.java
@@ -9,17 +9,17 @@ import server.main.allocation.entity.AllocationEvent;
 import server.main.allocation.repository.AllocationEventRepository;
 import server.main.asset.entity.Asset;
 import server.main.candle.entity.CandleDay;
-import server.main.candle.entity.CandleMonth;
-import server.main.candle.entity.CandleYear;
 import server.main.candle.repository.CandleDayRepository;
 import server.main.candle.repository.CandleMonthRepository;
 import server.main.candle.repository.CandleYearRepository;
+import server.main.candle.service.CandleLiveManager;
 import server.main.disclosure.entity.Disclosure;
 import server.main.disclosure.entity.DisclosureCategory;
 import server.main.disclosure.repository.DisclosureRepository;
 import server.main.global.error.BusinessException;
 import server.main.global.file.File;
 import server.main.global.file.FileRepository;
+import server.main.global.util.GeminiClient;
 import server.main.token.dto.PeriodType;
 import server.main.token.dto.SelectType;
 import server.main.token.dto.TokenAllocationInfoResponseDto;
@@ -40,7 +40,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class TokenServiceImplTest {
@@ -54,10 +56,11 @@ class TokenServiceImplTest {
     @Mock CandleDayRepository candleDayRepository;
     @Mock CandleMonthRepository candleMonthRepository;
     @Mock CandleYearRepository candleYearRepository;
+    @Mock CandleLiveManager candleLiveManager;
+    @Mock GeminiClient geminiClient;
 
     @InjectMocks
     TokenServiceImpl tokenService;
-
 
     @Test
     void getTokenDetail_정상조회() {
@@ -82,9 +85,7 @@ class TokenServiceImplTest {
         when(tokenRepository.findByIdWithAsset(999L)).thenReturn(Optional.empty());
 
         assertThrows(BusinessException.class, () -> tokenService.getTokenDetail(999L));
-        verify(tokenRepository).findByIdWithAsset(999L);
     }
-
 
     @Test
     void getTokenAssetInfo_정상조회() {
@@ -96,7 +97,6 @@ class TokenServiceImplTest {
                 .totalSupply(50000L)
                 .build();
         Token token = Token.builder().tokenId(1L).asset(asset).build();
-
         Disclosure disclosure = Disclosure.builder()
                 .disclosureId(10L)
                 .disclosureCategory(DisclosureCategory.BUILDING)
@@ -105,7 +105,7 @@ class TokenServiceImplTest {
         File file = File.builder()
                 .fileId(100L)
                 .disclosureId(10L)
-                .originName("건물_소개서.pdf")
+                .originName("건물_공시.pdf")
                 .build();
 
         when(tokenRepository.findByIdWithAsset(1L)).thenReturn(Optional.of(token));
@@ -117,7 +117,7 @@ class TokenServiceImplTest {
         assertThat(result.getInitPrice()).isEqualTo(10000L);
         assertThat(result.getTotalValue()).isEqualTo(500000000L);
         assertThat(result.getAssetAddress()).isEqualTo("서울시 강남구 테헤란로 123");
-        assertThat(result.getOriginName()).isEqualTo("건물_소개서.pdf");
+        assertThat(result.getOriginName()).isEqualTo("건물_공시.pdf");
         assertThat(result.getTotalSupply()).isEqualTo(50000L);
     }
 
@@ -129,23 +129,9 @@ class TokenServiceImplTest {
     }
 
     @Test
-    void getTokenAssetInfo_BUILDING_공시없음_예외() {
-        Asset asset = Asset.builder().assetId(1L).build();
-        Token token = Token.builder().tokenId(1L).asset(asset).build();
-
-        when(tokenRepository.findByIdWithAsset(1L)).thenReturn(Optional.of(token));
-        when(disclosureRepository.findByAssetIdAndCategory(1L)).thenReturn(Optional.empty());
-
-        assertThrows(BusinessException.class, () -> tokenService.getTokenAssetInfo(1L));
-    }
-
-
-
-    @Test
     void getAllocationInfo_정상조회() {
         Asset asset = Asset.builder().assetId(1L).build();
         Token token = Token.builder().tokenId(1L).totalSupply(1000L).asset(asset).build();
-
         LocalDateTime date1 = LocalDateTime.of(2024, 3, 20, 0, 0);
         LocalDateTime date2 = LocalDateTime.of(2023, 12, 20, 0, 0);
         List<AllocationEvent> events = List.of(
@@ -160,73 +146,24 @@ class TokenServiceImplTest {
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getSettledAt()).isEqualTo(date1);
-        assertThat(result.get(0).getMonthlyDividendIncome()).isEqualTo(500000L);
-        assertThat(result.get(0).getAllocationPerToken()).isEqualTo(500L);   // 500000 / 1000
-        assertThat(result.get(0).getAllocationBatchStatus()).isTrue();
+        assertThat(result.get(0).getAllocationPerToken()).isEqualTo(500L);
     }
 
     @Test
-    void getAllocationInfo_배당이벤트없음_빈리스트반환() {
+    void getAllocationInfo_이벤트없음_빈리스트() {
         Asset asset = Asset.builder().assetId(1L).build();
         Token token = Token.builder().tokenId(1L).totalSupply(1000L).asset(asset).build();
 
         when(tokenRepository.findByIdWithAsset(1L)).thenReturn(Optional.of(token));
         when(allocationEventRepository.findAllByAssetIdOrderBySettledAtDesc(1L)).thenReturn(List.of());
 
-        List<TokenAllocationInfoResponseDto> result = tokenService.getAllocationInfo(1L);
-
-        assertThat(result).isEmpty();
+        assertThat(tokenService.getAllocationInfo(1L)).isEmpty();
     }
 
     @Test
-    void getAllocationInfo_totalSupply가0이면_perToken은0() {
-        Asset asset = Asset.builder().assetId(1L).build();
-        Token token = Token.builder().tokenId(1L).totalSupply(0L).asset(asset).build(); // total supply = 0
-
-        List<AllocationEvent> events = List.of(
-                AllocationEvent.builder().allocationEventId(1L).monthlyDividendIncome(500000L)
-                        .settledAt(LocalDateTime.now()).allocationBatchStatus(true).build()
-        );
-
-        when(tokenRepository.findByIdWithAsset(1L)).thenReturn(Optional.of(token));
-        when(allocationEventRepository.findAllByAssetIdOrderBySettledAtDesc(1L)).thenReturn(events);
-
-        List<TokenAllocationInfoResponseDto> result = tokenService.getAllocationInfo(1L);
-
-        assertThat(result.get(0).getAllocationPerToken()).isEqualTo(0L);
-    }
-
-    @Test
-    void getAllocationInfo_totalSupplyNull이면_perToken은0() {
-        Asset asset = Asset.builder().assetId(1L).build();
-        Token token = Token.builder().tokenId(1L).totalSupply(null).asset(asset).build(); // total supply = null
-
-        List<AllocationEvent> events = List.of(
-                AllocationEvent.builder().allocationEventId(1L).monthlyDividendIncome(500000L)
-                        .settledAt(LocalDateTime.now()).allocationBatchStatus(false).build()
-        );
-
-        when(tokenRepository.findByIdWithAsset(1L)).thenReturn(Optional.of(token));
-        when(allocationEventRepository.findAllByAssetIdOrderBySettledAtDesc(1L)).thenReturn(events);
-
-        List<TokenAllocationInfoResponseDto> result = tokenService.getAllocationInfo(1L);
-
-        assertThat(result.get(0).getAllocationPerToken()).isEqualTo(0L);
-    }
-
-    @Test
-    void getAllocationInfo_토큰없음_예외() {
-        when(tokenRepository.findByIdWithAsset(999L)).thenReturn(Optional.empty());
-
-        assertThrows(BusinessException.class, () -> tokenService.getAllocationInfo(999L));
-    }
-
-
-    @Test
-    void getDisclosureInfo_정상조회_파일있음() {
+    void getDisclosureInfo_정상조회() {
         Asset asset = Asset.builder().assetId(1L).build();
         Token token = Token.builder().tokenId(1L).asset(asset).build();
-
         Disclosure disclosure = Disclosure.builder()
                 .disclosureId(10L)
                 .disclosureTitle("2024년 1분기 배당 공시")
@@ -234,11 +171,7 @@ class TokenServiceImplTest {
                 .disclosureCategory(DisclosureCategory.DIVIDEND)
                 .assetId(1L)
                 .build();
-        File file = File.builder()
-                .fileId(100L)
-                .disclosureId(10L)
-                .originName("공시문서.pdf")
-                .build();
+        File file = File.builder().fileId(100L).disclosureId(10L).originName("공시문서.pdf").build();
 
         when(tokenRepository.findByIdWithAsset(1L)).thenReturn(Optional.of(token));
         when(disclosureRepository.findAllByAssetId(1L)).thenReturn(List.of(disclosure));
@@ -248,68 +181,39 @@ class TokenServiceImplTest {
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getDisclosureTitle()).isEqualTo("2024년 1분기 배당 공시");
-        assertThat(result.get(0).getDisclosureCategory()).isEqualTo(DisclosureCategory.DIVIDEND);
         assertThat(result.get(0).getOriginName()).isEqualTo("공시문서.pdf");
     }
 
     @Test
-    void getDisclosureInfo_파일X공시_OriginNameNull() {
+    void getDisclosureInfo_파일없음_originNameNull() {
         Asset asset = Asset.builder().assetId(1L).build();
         Token token = Token.builder().tokenId(1L).asset(asset).build();
-
         Disclosure disclosure = Disclosure.builder()
                 .disclosureId(10L)
-                .disclosureTitle("건물 소개")
+                .disclosureTitle("건물 공시")
                 .disclosureCategory(DisclosureCategory.BUILDING)
                 .assetId(1L)
                 .build();
 
         when(tokenRepository.findByIdWithAsset(1L)).thenReturn(Optional.of(token));
         when(disclosureRepository.findAllByAssetId(1L)).thenReturn(List.of(disclosure));
-        when(fileRepository.findByDisclosureId(10L)).thenReturn(null);  // 파일 없음
+        when(fileRepository.findByDisclosureId(10L)).thenReturn(null);
 
         List<TokenDisclosureResponseDto> result = tokenService.getDisclosureInfo(1L);
 
-        assertThat(result.get(0).getOriginName()).isNull(); // assertThat ~ .isNull은 null 인지 확인, assertThrows는 예외가 터졌는지 확인
+        assertThat(result.get(0).getOriginName()).isNull();
     }
-
-    @Test
-    void getDisclosureInfo_공시없음_빈리스트반환() {
-        Asset asset = Asset.builder().assetId(1L).build();
-        Token token = Token.builder().tokenId(1L).asset(asset).build();
-
-        when(tokenRepository.findByIdWithAsset(1L)).thenReturn(Optional.of(token));
-        when(disclosureRepository.findAllByAssetId(1L)).thenReturn(List.of());
-
-        List<TokenDisclosureResponseDto> result = tokenService.getDisclosureInfo(1L);
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    void getDisclosureInfo_토큰없음_예외() {
-        when(tokenRepository.findByIdWithAsset(999L)).thenReturn(Optional.empty());
-
-        assertThrows(BusinessException.class, () -> tokenService.getDisclosureInfo(999L));
-    }
-
-
-    // ── getTokenAssetsWith10Paging ──────────────────────────────
 
     @Test
     void getTokenAssetsWith10Paging_BASIC_DAY_정상조회() {
         Asset asset = Asset.builder().assetId(1L).assetName("서울 빌딩").build();
         Token token = Token.builder().tokenId(1L).currentPrice(12000L).asset(asset).build();
-
-        CandleDay todayCandle = CandleDay.builder().openPrice(10000L).closePrice(11000L).token(token).build();
-        CandleDay sparkCandle = CandleDay.builder().closePrice(11500L).token(token).build();
+        CandleDay baseCandle = CandleDay.builder().closePrice(10000L).token(token).build();
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
-        when(candleDayRepository.findTodayByTokenIds(anyList(), any(), any())).thenReturn(List.of(todayCandle));
-        when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(
-                List.<Object[]>of(new Object[]{1L, 50000000L, 300L})
-        );
-        when(candleDayRepository.findRecentByTokenIds(anyList(), any())).thenReturn(List.of(sparkCandle));
+        when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of(baseCandle));
+        when(tradeRepository.findAggregatesByTokenIds(anyList()))
+                .thenReturn(List.<Object[]>of(new Object[]{1L, 50000000L, 300L}));
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.BASIC, PeriodType.DAY);
 
@@ -318,11 +222,11 @@ class TokenServiceImplTest {
         assertThat(dto.getTokenId()).isEqualTo(1L);
         assertThat(dto.getAssetName()).isEqualTo("서울 빌딩");
         assertThat(dto.getCurrentPrice()).isEqualTo(12000L);
+        assertThat(dto.getBasePrice()).isEqualTo(10000L);
         assertThat(dto.getTotalTradeValue()).isEqualTo(50000000L);
         assertThat(dto.getTotalTradeQuantity()).isEqualTo(300L);
-        // 등락률: (12000 - 10000) / 10000 * 100 = 20.0%
         assertThat(dto.getFluctuationRate()).isEqualTo(20.0);
-        assertThat(dto.getSparkLine()).containsExactly(11500L);
+        assertThat(dto.getSparkLine()).isEmpty();
     }
 
     @Test
@@ -336,31 +240,29 @@ class TokenServiceImplTest {
     }
 
     @Test
-    void getTokenAssetsWith10Paging_currentPrice가null이면_0으로처리() {
-        Asset asset = Asset.builder().assetId(1L).assetName("null가격 토큰").build();
+    void getTokenAssetsWith10Paging_currentPrice가Null이면_0으로처리() {
+        Asset asset = Asset.builder().assetId(1L).assetName("null가격토큰").build();
         Token token = Token.builder().tokenId(1L).currentPrice(null).asset(asset).build();
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
-        when(candleDayRepository.findTodayByTokenIds(anyList(), any(), any())).thenReturn(List.of());
+        when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of());
         when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(List.of());
-        when(candleDayRepository.findRecentByTokenIds(anyList(), any())).thenReturn(List.of());
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.BASIC, PeriodType.DAY);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getCurrentPrice()).isEqualTo(0L);
-        assertThat(result.get(0).getFluctuationRate()).isEqualTo(0.0);  // basePrice도 없으므로 0
+        assertThat(result.get(0).getFluctuationRate()).isEqualTo(0.0);
     }
 
     @Test
-    void getTokenAssetsWith10Paging_거래없는토큰_집계기본값0() {
-        Asset asset = Asset.builder().assetId(1L).assetName("무거래 토큰").build();
+    void getTokenAssetsWith10Paging_거래없는토큰_집계기본값() {
+        Asset asset = Asset.builder().assetId(1L).assetName("무거래토큰").build();
         Token token = Token.builder().tokenId(1L).currentPrice(5000L).asset(asset).build();
 
         when(tokenRepository.findAllBySelectType(0, SelectType.TOTAL_TRADE_VALUE)).thenReturn(List.of(token));
-        when(candleDayRepository.findTodayByTokenIds(anyList(), any(), any())).thenReturn(List.of());
-        when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(List.of());  // 거래 없음
-        when(candleDayRepository.findRecentByTokenIds(anyList(), any())).thenReturn(List.of());
+        when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of());
+        when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(List.of());
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.TOTAL_TRADE_VALUE, PeriodType.DAY);
 
@@ -374,9 +276,8 @@ class TokenServiceImplTest {
         Token token = Token.builder().tokenId(1L).currentPrice(8000L).asset(asset).build();
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
-        when(candleDayRepository.findTodayByTokenIds(anyList(), any(), any())).thenReturn(List.of());  // 시가 없음
+        when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of());
         when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(List.of());
-        when(candleDayRepository.findRecentByTokenIds(anyList(), any())).thenReturn(List.of());
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.BASIC, PeriodType.DAY);
 
@@ -384,66 +285,62 @@ class TokenServiceImplTest {
     }
 
     @Test
-    void getTokenAssetsWith10Paging_MONTH_candleMonth사용() {
+    void getTokenAssetsWith10Paging_MONTH도_day기준BasePrice를사용() {
         Asset asset = Asset.builder().assetId(1L).assetName("월간 토큰").build();
         Token token = Token.builder().tokenId(1L).currentPrice(20000L).asset(asset).build();
-
-        CandleMonth monthCandle = CandleMonth.builder().openPrice(18000L).closePrice(19000L).token(token).build();
+        CandleDay baseCandle = CandleDay.builder().closePrice(18000L).token(token).build();
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
-        when(candleMonthRepository.findThisMonthByTokenIds(anyList(), any(), any())).thenReturn(List.of(monthCandle));
+        when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of(baseCandle));
         when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(List.of());
-        when(candleMonthRepository.findRecentByTokenIds(anyList(), any())).thenReturn(List.of(monthCandle));
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.BASIC, PeriodType.MONTH);
 
         assertThat(result).hasSize(1);
-        // 등락률: (20000 - 18000) / 18000 * 100 ≈ 11.11%
-        assertThat(result.get(0).getFluctuationRate()).isEqualTo(Math.round((20000.0 - 18000.0) / 18000.0 * 100.0 * 100.0) / 100.0);
-        verifyNoInteractions(candleDayRepository, candleYearRepository);
+        assertThat(result.get(0).getFluctuationRate())
+                .isEqualTo(Math.round((20000.0 - 18000.0) / 18000.0 * 100.0 * 100.0) / 100.0);
+        verifyNoInteractions(candleMonthRepository, candleYearRepository);
     }
 
     @Test
-    void getTokenAssetsWith10Paging_YEAR_candleYear사용() {
+    void getTokenAssetsWith10Paging_YEAR도_day기준BasePrice를사용() {
         Asset asset = Asset.builder().assetId(1L).assetName("연간 토큰").build();
         Token token = Token.builder().tokenId(1L).currentPrice(30000L).asset(asset).build();
-
-        CandleYear yearCandle = CandleYear.builder().openPrice(25000L).closePrice(28000L).token(token).build();
+        CandleDay baseCandle = CandleDay.builder().closePrice(25000L).token(token).build();
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
-        when(candleYearRepository.findThisYearByTokenIds(anyList(), any(), any())).thenReturn(List.of(yearCandle));
+        when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of(baseCandle));
         when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(List.of());
-        when(candleYearRepository.findRecentByTokenIds(anyList(), any())).thenReturn(List.of());
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.BASIC, PeriodType.YEAR);
 
         assertThat(result).hasSize(1);
+        assertThat(result.get(0).getBasePrice()).isEqualTo(25000L);
         assertThat(result.get(0).getSparkLine()).isEmpty();
-        verifyNoInteractions(candleDayRepository, candleMonthRepository);
+        verifyNoInteractions(candleMonthRepository, candleYearRepository);
     }
 
     @Test
-    void getTokenAssetsWith10Paging_스파크라인_복수토큰_tokenId별그룹핑() {
+    void getTokenAssetsWith10Paging_복수토큰_basePrice매핑() {
         Asset asset1 = Asset.builder().assetId(1L).assetName("A토큰").build();
         Asset asset2 = Asset.builder().assetId(2L).assetName("B토큰").build();
         Token token1 = Token.builder().tokenId(1L).currentPrice(1000L).asset(asset1).build();
         Token token2 = Token.builder().tokenId(2L).currentPrice(2000L).asset(asset2).build();
-
-        CandleDay spark1a = CandleDay.builder().closePrice(900L).token(token1).build();
-        CandleDay spark1b = CandleDay.builder().closePrice(950L).token(token1).build();
-        CandleDay spark2a = CandleDay.builder().closePrice(1800L).token(token2).build();
+        CandleDay base1 = CandleDay.builder().closePrice(900L).token(token1).build();
+        CandleDay base2 = CandleDay.builder().closePrice(1800L).token(token2).build();
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token1, token2));
-        when(candleDayRepository.findTodayByTokenIds(anyList(), any(), any())).thenReturn(List.of());
+        when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of(base1, base2));
         when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(List.of());
-        when(candleDayRepository.findRecentByTokenIds(anyList(), any())).thenReturn(List.of(spark1a, spark1b, spark2a));
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.BASIC, PeriodType.DAY);
 
         TokenMainResponseDto dto1 = result.stream().filter(d -> d.getTokenId() == 1L).findFirst().orElseThrow();
         TokenMainResponseDto dto2 = result.stream().filter(d -> d.getTokenId() == 2L).findFirst().orElseThrow();
 
-        assertThat(dto1.getSparkLine()).containsExactly(900L, 950L);
-        assertThat(dto2.getSparkLine()).containsExactly(1800L);
+        assertThat(dto1.getBasePrice()).isEqualTo(900L);
+        assertThat(dto2.getBasePrice()).isEqualTo(1800L);
+        assertThat(dto1.getSparkLine()).isEmpty();
+        assertThat(dto2.getSparkLine()).isEmpty();
     }
 }

--- a/server/match/src/main/java/server/match/order/OrderBookInitializer.java
+++ b/server/match/src/main/java/server/match/order/OrderBookInitializer.java
@@ -28,6 +28,7 @@ public class OrderBookInitializer implements ApplicationRunner {
                 SELECT order_id, member_id, token_id, order_type, order_price, remaining_quantity
                 FROM orders
                 WHERE order_status IN ('OPEN', 'PARTIAL')
+                  AND remaining_quantity > 0
                 """;
 
         jdbcTemplate.query(sql, rs -> {

--- a/server/match/src/main/java/server/match/order/model/Order.java
+++ b/server/match/src/main/java/server/match/order/model/Order.java
@@ -16,6 +16,9 @@ public class Order {
     private Long sequence;          // 오더북 삽입 시 부여되는 시간 우선순위 번호
 
     public Order(Long orderId, Long memberId, Long tokenId, OrderType orderType, Long price, Long quantity) {
+        if (quantity == null || quantity <= 0) {
+            throw new IllegalArgumentException("remainingQuantity must be positive");
+        }
         this.orderId = orderId;
         this.memberId = memberId;
         this.tokenId = tokenId;
@@ -25,6 +28,9 @@ public class Order {
     }
 
     public void reduceQuantity(Long amount) {
+        if (amount == null || amount <= 0 || amount > this.remainingQuantity) {
+            throw new IllegalArgumentException("invalid reduce amount");
+        }
         this.remainingQuantity -= amount;
     }
 
@@ -35,6 +41,9 @@ public class Order {
 
     // 수량 감소 시 in-place 수정 — 오더북 줄 위치(시간 우선순위) 유지
     public void updateQuantity(Long newQuantity) {
+        if (newQuantity == null || newQuantity <= 0) {
+            throw new IllegalArgumentException("remainingQuantity must be positive");
+        }
         this.remainingQuantity = newQuantity;
     }
 

--- a/server/match/src/main/java/server/match/order/service/MatchingService.java
+++ b/server/match/src/main/java/server/match/order/service/MatchingService.java
@@ -54,7 +54,20 @@ public class MatchingService {
                 long incomingRemaining = incomingOrder.getRemainingQuantity();
                 long counterRemaining = counterOrder.getRemainingQuantity();
                 if (incomingRemaining <= 0 || counterRemaining <= 0) {
-                    throw new IllegalStateException("Order book contains non-positive remaining quantity");
+                    throw new IllegalStateException(
+                            "Order book contains non-positive remaining quantity: tokenId="
+                                    + incomingOrder.getTokenId()
+                                    + ", incomingOrderId="
+                                    + incomingOrder.getOrderId()
+                                    + ", counterOrderId="
+                                    + counterOrder.getOrderId()
+                                    + ", price="
+                                    + bestPrice
+                                    + ", incomingRemaining="
+                                    + incomingRemaining
+                                    + ", counterRemaining="
+                                    + counterRemaining
+                    );
                 }
 
                 long tradeQuantity = Math.min(incomingRemaining, counterRemaining);

--- a/server/match/src/main/java/server/match/order/service/MatchingService.java
+++ b/server/match/src/main/java/server/match/order/service/MatchingService.java
@@ -43,8 +43,7 @@ public class MatchingService {
                 Deque<Order> queue = bestEntry.getValue();
                 Order counterOrder = queue.peek();
                 if (counterOrder == null) {
-                    counterBook.remove(bestPrice);
-                    continue;
+                    throw new IllegalStateException("Order book contains an empty price level at price: " + bestPrice);
                 }
 
 //                // STP: 자기 자신과는 체결하지 않음

--- a/server/match/src/main/java/server/match/order/service/MatchingService.java
+++ b/server/match/src/main/java/server/match/order/service/MatchingService.java
@@ -42,13 +42,26 @@ public class MatchingService {
 
                 Deque<Order> queue = bestEntry.getValue();
                 Order counterOrder = queue.peek();
+                if (counterOrder == null) {
+                    counterBook.remove(bestPrice);
+                    continue;
+                }
 
 //                // STP: 자기 자신과는 체결하지 않음
 //                if (incomingOrder.getMemberId().equals(counterOrder.getMemberId())) {
 //                    break;
 //                }
 
-                long tradeQuantity = Math.min(incomingOrder.getRemainingQuantity(), counterOrder.getRemainingQuantity());
+                long incomingRemaining = incomingOrder.getRemainingQuantity();
+                long counterRemaining = counterOrder.getRemainingQuantity();
+                if (incomingRemaining <= 0 || counterRemaining <= 0) {
+                    throw new IllegalStateException("Order book contains non-positive remaining quantity");
+                }
+
+                long tradeQuantity = Math.min(incomingRemaining, counterRemaining);
+                if (tradeQuantity <= 0) {
+                    throw new IllegalStateException("Trade quantity must be positive");
+                }
 
                 incomingOrder.reduceQuantity(tradeQuantity);
                 counterOrder.reduceQuantity(tradeQuantity);


### PR DESCRIPTION
## Summary
- add main/match-side validation guards to block invalid match results from being persisted
- isolate phase 2 match processing failures, automatically retry failed orders, and cancel them after 3 failed retries
- tighten blockchain trade tx validation and restrict the blockchain test controller to the local profile

## Details
- validate `MatchResultDto` and each execution before updating orders, trades, holdings, and outbox records
- reject non-positive remaining quantities in the match order book and invalid quantity updates in match order objects
- mark orders as `FAILED` when phase 2 processing fails, retry them on a scheduler, and release locked resources by cancelling after the retry limit
- add `retry_count` schema support for `orders`
- require `trade` and `queueId` for `TRADE` blockchain tx rows

## Verification
- `server/match`: `./gradlew.bat compileJava` succeeded earlier during the work
- `server/main`: full compile is still blocked by pre-existing `server.main.myAccount.*` missing-symbol errors unrelated to this change
- applied `orders.retry_count integer not null default 0` to the Postgres `stodb.public.orders` table and verified the column exists