### PR TITLE
fix: 주문내역 실제 체결 정산금액 표시

### DIFF
--- a/client/web/src/pages/MyAccountPage.jsx
+++ b/client/web/src/pages/MyAccountPage.jsx
@@ -678,6 +678,10 @@ function OrdersTab({
     return `${date} ${time}`;
   }
 
+  function formatWon(value) {
+    return Number(value ?? 0).toLocaleString();
+  }
+
   return (
     <div className="space-y-8">
       <div className="flex items-center justify-between">
@@ -765,8 +769,9 @@ function OrdersTab({
                       </span>
                     </div>
                     <p className="text-[10px] text-stone-400 font-bold mt-0.5">
-                      {order.orderPrice.toLocaleString()}원 |{" "}
-                      {order.orderQuantity}주
+                      지정가 {formatWon(order.orderPrice)}원 | {order.orderQuantity}주
+                      {order.filledQuantity > 0 &&
+                        ` | 체결가 ${formatWon(order.averageTradePrice)}원`}
                       {order.orderStatus !== "FILLED" &&
                         ` (잔량 ${order.remainingQuantity}주)`}
                     </p>
@@ -776,13 +781,10 @@ function OrdersTab({
                   {order.orderStatus === "FILLED" ? (
                     <div>
                       <p className="text-sm font-black text-stone-800">
-                        {(
-                          order.orderPrice * order.filledQuantity
-                        )?.toLocaleString()}
-                        원
+                        {formatWon(order.settlementAmount)}원
                       </p>
                       <span className="text-[10px] font-black text-brand-red uppercase tracking-widest">
-                        체결완료
+                        {order.orderType === "BUY" ? "실제 지불" : "실제 수령"}
                       </span>
                     </div>
                   ) : order.orderStatus === "CANCELLED" ||

--- a/server/main/src/main/java/server/main/myAccount/dto/OrderHistoryResponse.java
+++ b/server/main/src/main/java/server/main/myAccount/dto/OrderHistoryResponse.java
@@ -21,9 +21,22 @@ public class OrderHistoryResponse {
     private Long orderQuantity;
     private Long filledQuantity;
     private Long remainingQuantity;
+    private Long averageTradePrice;
+    private Long executedTradeAmount;
+    private Long feeAmount;
+    private Long settlementAmount;
     private LocalDateTime createdAt;
 
-    public static OrderHistoryResponse from(Order order) {
+    public static OrderHistoryResponse from(Order order, Object[] executionSummary) {
+        Long executedTradeAmount = numberAt(executionSummary, 0);
+        Long feeAmount = numberAt(executionSummary, 1);
+        Long executedQuantity = numberAt(executionSummary, 2);
+        Long averageTradePrice = executedQuantity > 0 ? executedTradeAmount / executedQuantity : 0L;
+        Long settlementAmount = switch (order.getOrderType()) {
+            case BUY -> executedTradeAmount + feeAmount;
+            case SELL -> executedTradeAmount - feeAmount;
+        };
+
         return new OrderHistoryResponse(
                 order.getOrderId(),
                 order.getToken().getTokenSymbol(),
@@ -34,9 +47,18 @@ public class OrderHistoryResponse {
                 order.getOrderQuantity(),
                 order.getFilledQuantity(),
                 order.getRemainingQuantity(),
+                averageTradePrice,
+                executedTradeAmount,
+                feeAmount,
+                settlementAmount,
                 order.getCreatedAt()
         );
     }
 
-
+    private static Long numberAt(Object[] values, int index) {
+        if (values == null || values.length <= index || values[index] == null) {
+            return 0L;
+        }
+        return ((Number) values[index]).longValue();
+    }
 }

--- a/server/main/src/main/java/server/main/myAccount/service/MyAccountServiceImpl.java
+++ b/server/main/src/main/java/server/main/myAccount/service/MyAccountServiceImpl.java
@@ -165,7 +165,10 @@ public class MyAccountServiceImpl implements MyAccountService{
         } else {
             orders = orderRepository.findAllByMemberId(memberId,pageable);
         }
-        return orders.map(OrderHistoryResponse::from);
+        return orders.map(order -> OrderHistoryResponse.from(
+                order,
+                tradeRepository.findExecutionSummaryByOrderId(order.getOrderId())
+        ));
     }
 
     @Override

--- a/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
+++ b/server/main/src/main/java/server/main/order/service/OrderServiceImpl.java
@@ -317,6 +317,8 @@ public class OrderServiceImpl implements OrderService {
         Member findMember = findOrder.getMember();
         Long memberId = findMember.getMemberId();
 
+        validateMatchResult(findOrder, tokenId, matchResult);
+
         // ORDERS 테이블 업데이트 — match 서버는 누적 체결을 모르므로 main 에서 상태 재계산
         long newTotalFilled = findOrder.getFilledQuantity() + matchResult.getFilledQuantity();
 
@@ -806,6 +808,13 @@ public class OrderServiceImpl implements OrderService {
         Order findOrder = orderRepository.findByMemberIdAndOrderId(memberId, orderId)
                 .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUNT_ERROR));
 
+        OrderStatus status = findOrder.getOrderStatus();
+        if (status != OrderStatus.OPEN && status != OrderStatus.PARTIAL) {
+            throw new BusinessException(ORDER_NOT_MODIFIABLE);
+        } else if (status == OrderStatus.PARTIAL && dto.getUpdateQuantity() <= findOrder.getFilledQuantity()) {
+            throw new BusinessException(INVALID_UPDATE_QUANTITY);
+        }
+
         // 호가 단위 검증
         TickSizePolicy.validate(dto.getUpdatePrice());
 
@@ -820,13 +829,6 @@ public class OrderServiceImpl implements OrderService {
             if (dto.getUpdatePrice() > upper) throw new BusinessException(PRICE_OVER_LIMIT);
             if (dto.getUpdatePrice() < lower) throw new BusinessException(PRICE_UNDER_LIMIT);
         });
-
-        OrderStatus status = findOrder.getOrderStatus();
-        if (status != OrderStatus.OPEN && status != OrderStatus.PARTIAL) {
-            throw new BusinessException(ORDER_NOT_MODIFIABLE);
-        } else if (status == OrderStatus.PARTIAL && dto.getUpdateQuantity() <= findOrder.getFilledQuantity()) {
-            throw new BusinessException(INVALID_UPDATE_QUANTITY);
-        }
 
         long newRemaining = dto.getUpdateQuantity() - findOrder.getFilledQuantity();
         double chargeRate = getChargeRate();

--- a/server/main/src/main/java/server/main/trade/repository/TradeRepository.java
+++ b/server/main/src/main/java/server/main/trade/repository/TradeRepository.java
@@ -110,4 +110,14 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
             @Param("end") LocalDateTime end,
             Pageable pageable
     );
+
+    @Query("""
+        SELECT COALESCE(SUM(t.totalTradePrice), 0),
+               COALESCE(SUM(t.feeAmount), 0),
+               COALESCE(SUM(t.tradeQuantity), 0)
+        FROM Trade t
+        WHERE t.buyOrder.orderId = :orderId
+           OR t.sellOrder.orderId = :orderId
+    """)
+    Object[] findExecutionSummaryByOrderId(@Param("orderId") Long orderId);
 }

--- a/server/main/src/test/java/server/main/order/service/OrderServiceImplTest.java
+++ b/server/main/src/test/java/server/main/order/service/OrderServiceImplTest.java
@@ -32,6 +32,7 @@ import server.main.admin.repository.CommonRepository;
 import server.main.admin.repository.PlatformAccountRepository;
 import server.main.admin.repository.PlatformBankingRepository;
 import server.main.blockchain.service.BlockchainOutboxService;
+import server.main.candle.repository.CandleDayRepository;
 import server.main.global.error.BusinessException;
 import server.main.global.security.CustomUserPrincipal;
 import server.main.global.util.MatchClient;
@@ -86,6 +87,7 @@ class OrderServiceImplTest {
     @Mock PlatformBankingRepository platformBankingRepository;
     @Mock PlatformAccount platformAccount;
     @Mock PlatformTransactionManager transactionManager;
+    @Mock CandleDayRepository candleDayRepository;
 
     @InjectMocks
     OrderServiceImpl orderService;

--- a/server/main/src/test/java/server/main/token/service/TokenServiceImplTest.java
+++ b/server/main/src/test/java/server/main/token/service/TokenServiceImplTest.java
@@ -212,7 +212,7 @@ class TokenServiceImplTest {
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
         when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of(baseCandle));
-        when(tradeRepository.findAggregatesByTokenIds(anyList()))
+        when(tradeRepository.findAggregatesByTokenIds(anyList(), any()))
                 .thenReturn(List.<Object[]>of(new Object[]{1L, 50000000L, 300L}));
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.BASIC, PeriodType.DAY);
@@ -246,7 +246,7 @@ class TokenServiceImplTest {
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
         when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of());
-        when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(List.of());
+        when(tradeRepository.findAggregatesByTokenIds(anyList(), any())).thenReturn(List.of());
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.BASIC, PeriodType.DAY);
 
@@ -262,7 +262,7 @@ class TokenServiceImplTest {
 
         when(tokenRepository.findAllBySelectType(0, SelectType.TOTAL_TRADE_VALUE)).thenReturn(List.of(token));
         when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of());
-        when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(List.of());
+        when(tradeRepository.findAggregatesByTokenIds(anyList(), any())).thenReturn(List.of());
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.TOTAL_TRADE_VALUE, PeriodType.DAY);
 
@@ -277,7 +277,7 @@ class TokenServiceImplTest {
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
         when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of());
-        when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(List.of());
+        when(tradeRepository.findAggregatesByTokenIds(anyList(), any())).thenReturn(List.of());
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.BASIC, PeriodType.DAY);
 
@@ -292,7 +292,7 @@ class TokenServiceImplTest {
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
         when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of(baseCandle));
-        when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(List.of());
+        when(tradeRepository.findAggregatesByTokenIds(anyList(), any())).thenReturn(List.of());
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.BASIC, PeriodType.MONTH);
 
@@ -310,7 +310,7 @@ class TokenServiceImplTest {
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token));
         when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of(baseCandle));
-        when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(List.of());
+        when(tradeRepository.findAggregatesByTokenIds(anyList(), any())).thenReturn(List.of());
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.BASIC, PeriodType.YEAR);
 
@@ -331,7 +331,7 @@ class TokenServiceImplTest {
 
         when(tokenRepository.findAllBySelectType(0, SelectType.BASIC)).thenReturn(List.of(token1, token2));
         when(candleDayRepository.findLatestBeforeByTokenIds(anyList(), any())).thenReturn(List.of(base1, base2));
-        when(tradeRepository.findAggregatesByTokenIds(anyList())).thenReturn(List.of());
+        when(tradeRepository.findAggregatesByTokenIds(anyList(), any())).thenReturn(List.of());
 
         List<TokenMainResponseDto> result = tokenService.getTokenAssetsWith10Paging(0, SelectType.BASIC, PeriodType.DAY);
 


### PR DESCRIPTION
## Summary
- 주문내역 응답에 실제 평균체결가, 체결금액, 수수료, 정산금액을 추가했습니다.
- 마이페이지 주문내역에서 지정가 기준 금액 대신 실제 지불/수령 금액을 표시하도록 수정했습니다.
- 매칭 서버 응답을 DB 반영 전에 `validateMatchResult()`로 검증하도록 연결했습니다.
- 최신 dev 기준 테스트 mock 시그니처와 주문 수정 상태 검증 순서를 정리했습니다.

## Verification
- `server/main`: `./gradlew.bat test`
- `client/web`: `npm run build`